### PR TITLE
Guard Coils.dofs_currents against None/bool sentinels (fixes tracing crash on #42)

### DIFF
--- a/essos/coils.py
+++ b/essos/coils.py
@@ -633,6 +633,9 @@ class Coils:
     # dofs_currents property and setter
     @property
     def dofs_currents(self):
+        # Sentinel leaf during PyTree traversal: pass through, don't scale.
+        if self._dofs_currents_raw is None or isinstance(self._dofs_currents_raw, bool):
+            return self._dofs_currents_raw
         if self._dofs_currents is None:
             dofs_currents = self.dofs_currents_raw / self.currents_scale
             if not isinstance(dofs_currents, jax.core.Tracer):


### PR DESCRIPTION
Small guard for the None is not a valid value for jnp.array crash that #42 still hits during tracing. Coils.dofs_currents now passes a sentinel leaf (None / bool from eqx.partition) straight through instead of doing jnp.array(None) / currents_scale.

Verified on this branch (en/review_eg/examples_fix): from_simsopt + eqx.partition works, and trace_particles_coils_guidingcenter.py runs clean.