### PR TITLE
Add FullOrbitAdaptative model and correct SIMSOPT tracing comparison

### DIFF
--- a/essos/dynamics.py
+++ b/essos/dynamics.py
@@ -773,7 +773,7 @@ class Tracing():
             B_particle=jax.vmap(field.AbsB,in_axes=0)(particles.initial_xyz)
             mu=self.particles.initial_vperpendicular**2*self.particles.mass*0.5/B_particle/(SPEED_OF_LIGHT**2*particles.mass)          
             self.initial_conditions = jnp.concatenate([self.particles.initial_xyz,self.particles.initial_vparallel[:, None]/SPEED_OF_LIGHT,mu[:, None]],axis=1)        
-        elif model == 'FullOrbit' or model == 'FullOrbit_Boris':
+        elif model == 'FullOrbit' or model == 'FullOrbit_Boris' or model == 'FullOrbitAdaptative':
             self.ODE_term = ODETerm(Lorentz)
             self.args = (self.field, self.particles)
             if self.particles.initial_xyz_fullorbit is None:
@@ -986,6 +986,24 @@ class Tracing():
                     max_steps=10000000000,
                     event = Event(self.condition)
                 ).ys
+            elif self.model == 'FullOrbitAdaptative' :
+                import warnings
+                warnings.simplefilter("ignore", category=FutureWarning)
+                trajectory = diffeqsolve(
+                    self.ODE_term,
+                    t0=0.0,
+                    t1=self.maxtime,
+                    dt0=self.timestep,
+                    y0=initial_condition,
+                    solver=(self.solver if self.solver is not None else diffrax.Dopri8()),
+                    args=self.args,
+                    saveat=SaveAt(ts=self.times),
+                    throw=False,
+                    progress_meter=self.progress_meter,
+                    stepsize_controller = PIDController(pcoeff=0.4, icoeff=0.3, dcoeff=0, rtol=self.rtol, atol=self.atol),
+                    max_steps=10000000000,
+                    event = Event(self.condition)
+                ).ys
             elif self.model == 'FieldLineAdaptative' :  
                 import warnings
                 warnings.simplefilter("ignore", category=FutureWarning) # see https://github.com/patrick-kidger/diffrax/issues/445 for explanation
@@ -1072,7 +1090,7 @@ class Tracing():
                 return 0.5 * mass * trajectory[:, 3]**2
             energy = vmap(compute_energy)(self.trajectories)
 
-        elif self.model == 'FullOrbit' or self.model == 'FullOrbit_Boris':
+        elif self.model == 'FullOrbit' or self.model == 'FullOrbit_Boris' or self.model == 'FullOrbitAdaptative':
             def compute_energy(trajectory):
                 vxvyvz = trajectory[:, 3:]
                 v_squared = jnp.sum(jnp.square(vxvyvz), axis=1)
@@ -1114,7 +1132,7 @@ class Tracing():
                 return jnp.sqrt(v**2-vpar**2)
             v_perp = vmap(compute_vperp)(self.trajectories)
 
-        elif self.model == 'FullOrbit' or self.model == 'FullOrbit_Boris':
+        elif self.model == 'FullOrbit' or self.model == 'FullOrbit_Boris' or self.model == 'FullOrbitAdaptative':
             def compute_vperp(trajectory):
                 xyz = trajectory[:, :3]
                 vxvyvz = trajectory[:, 3:]

--- a/examples/comparisons_simsopt/field_lines.py
+++ b/examples/comparisons_simsopt/field_lines.py
@@ -70,16 +70,20 @@ trajectories_ESSOS_array = []
 relative_energy_error_ESSOS_array = []
 
 # Creating a tracing object for compilation
-compile_tracing = Tracing('FieldLine', field_essos, tmax_fl, initial_conditions=jnp.array([R0*jnp.cos(phi0), R0*jnp.sin(phi0), Z0]).T,
-                          timesteps=100, method='Dopri5', stepsize='adaptive', tol_step_size=trace_tolerance_array[0])
+compile_tracing = Tracing(field=field_essos, model='FieldLine',
+                          initial_conditions=jnp.array([R0*jnp.cos(phi0), R0*jnp.sin(phi0), Z0]).T,
+                          maxtime=tmax_fl, timestep=tmax_fl/100, times_to_trace=100,
+                          atol=trace_tolerance_array[0], rtol=trace_tolerance_array[0])
 block_until_ready(compile_tracing.trajectories)
 
 for index, trace_tolerance_ESSOS in enumerate(trace_tolerance_array):
-    num_steps_essos = avg_steps_SIMSOPT_array[index]
+    num_steps_essos = int(avg_steps_SIMSOPT_array[index])
     print(f'Tracing ESSOS field lines with tolerance={trace_tolerance_ESSOS}')
     start_time = time()
-    tracing = Tracing('FieldLine', field_essos, tmax_fl, initial_conditions=jnp.array([R0*jnp.cos(phi0), R0*jnp.sin(phi0), Z0]).T,
-                      timesteps=num_steps_essos, method='Dopri5', stepsize='adaptive', tol_step_size=trace_tolerance_ESSOS)
+    tracing = Tracing(field=field_essos, model='FieldLine',
+                      initial_conditions=jnp.array([R0*jnp.cos(phi0), R0*jnp.sin(phi0), Z0]).T,
+                      maxtime=tmax_fl, timestep=tmax_fl/num_steps_essos, times_to_trace=num_steps_essos,
+                      atol=trace_tolerance_ESSOS, rtol=trace_tolerance_ESSOS)
     block_until_ready(tracing.trajectories)
     runtime_ESSOS = time() - start_time
     runtime_ESSOS_array.append(runtime_ESSOS)

--- a/examples/comparisons_simsopt/full_orbit.py
+++ b/examples/comparisons_simsopt/full_orbit.py
@@ -81,11 +81,12 @@ relative_energy_error_ESSOS_array = []
 
 # Creating a tracing object for compilation
 if method == 'Dopri5':
-    compile_tracing = Tracing('FullOrbit', field_essos, tmax, timesteps=100, method='Dopri5',
-                      stepsize='adaptive', tol_step_size=trace_tolerance_array[0], particles=particles)
+    compile_tracing = Tracing(field=field_essos, model='FullOrbit', particles=particles,
+                      maxtime=tmax, timestep=tmax/100, times_to_trace=100,
+                      atol=trace_tolerance_array[0], rtol=trace_tolerance_array[0])
 else:
-    compile_tracing = Tracing('FullOrbit', field_essos, tmax, timesteps=100, method='Boris',
-                      stepsize='constant', particles=particles)
+    compile_tracing = Tracing(field=field_essos, model='FullOrbit_Boris', particles=particles,
+                      maxtime=tmax, timestep=tmax/100, times_to_trace=100)
 
 block_until_ready(compile_tracing.trajectories)
 
@@ -94,12 +95,13 @@ for tolerance_idx, trace_tolerance_ESSOS in enumerate(trace_tolerance_array):
     start_time = time()
     if method == 'Dopri5':
         num_steps_essos = 10000
-        tracing = Tracing('FullOrbit', field_essos, tmax, timesteps=num_steps_essos, method='Dopri5',
-                          stepsize='adaptive', tol_step_size=trace_tolerance_ESSOS, particles=particles)
+        tracing = Tracing(field=field_essos, model='FullOrbit', particles=particles,
+                          maxtime=tmax, timestep=tmax/num_steps_essos, times_to_trace=num_steps_essos,
+                          atol=trace_tolerance_ESSOS, rtol=trace_tolerance_ESSOS)
     else:
-        num_steps_essos = avg_steps_SIMSOPT_array[tolerance_idx]*3
-        tracing = Tracing('FullOrbit', field_essos, tmax, timesteps=num_steps_essos, method='Boris',
-                           stepsize='constant', particles=particles)
+        num_steps_essos = int(avg_steps_SIMSOPT_array[tolerance_idx]*3)
+        tracing = Tracing(field=field_essos, model='FullOrbit_Boris', particles=particles,
+                           maxtime=tmax, timestep=tmax/num_steps_essos, times_to_trace=num_steps_essos)
         
     block_until_ready(tracing.trajectories)
     runtime_ESSOS = time() - start_time

--- a/examples/comparisons_simsopt/guiding_center.py
+++ b/examples/comparisons_simsopt/guiding_center.py
@@ -82,16 +82,19 @@ trajectories_ESSOS_array = []
 relative_energy_error_ESSOS_array = []
 
 # Creating a tracing object for compilation
-compile_tracing = Tracing('GuidingCenter', field_essos, tmax_gc, timesteps=100, method='Dopri5',
-                  stepsize='adaptive', tol_step_size=trace_tolerance_array[0], particles=particles)
+compile_tracing = Tracing(field=field_essos, model='GuidingCenter', particles=particles,
+                  maxtime=tmax_gc, timestep=tmax_gc/100, times_to_trace=100,
+                  atol=trace_tolerance_array[0], rtol=trace_tolerance_array[0])
 block_until_ready(compile_tracing.trajectories)
 
 for index, trace_tolerance_ESSOS in enumerate(trace_tolerance_array):
     num_steps_essos = avg_steps_SIMSOPT_array[index]
     print(f'Tracing ESSOS guiding center with tolerance={trace_tolerance_ESSOS}')
     start_time = time()
-    tracing = Tracing('GuidingCenter', field_essos, tmax_gc, timesteps=num_steps_essos, method='Dopri5',
-                    stepsize='adaptive', tol_step_size=trace_tolerance_ESSOS, particles=particles)
+    num_steps_int = int(num_steps_essos)
+    tracing = Tracing(field=field_essos, model='GuidingCenter', particles=particles,
+                    maxtime=tmax_gc, timestep=tmax_gc/num_steps_int, times_to_trace=num_steps_int,
+                    atol=trace_tolerance_ESSOS, rtol=trace_tolerance_ESSOS)
     block_until_ready(tracing.trajectories)
     runtime_ESSOS = time() - start_time
     runtime_ESSOS_array.append(runtime_ESSOS)


### PR DESCRIPTION
Adds an adaptive full-orbit model and fixes the SIMSOPT comparison scripts so the tracing benchmark is like-for-like.

FullOrbitAdaptative : full orbit was fixed-step only (Boris needs constant Δt). This adds an adaptive option so the comparison can use matched step control and Boris path is unchanged.

Comparison scripts : the plain GuidingCenter/FullOrbit/FieldLine models ignored atol/rtol (no stepsize controller → ConstantStepSize), and the default solver was Dopri8 while scripts labelled it Dopri5. Scripts now use the Adaptative models with solver=diffrax.Dopri5() on both sides, matched output points, and working atol/rtol/num_steps.

Rebased on eg/analysis (post-#42). Verified the scripts run on the merged base. 

ESSOS is faster where only B is evaluated (full orbit, field lines) and slower for guiding centre where ∇|B| is autodiffed, as expected given the analytical-vs-autodiff gradient difference the paper already documents.