### PR TITLE
Consume pyQSC_JAX external 3+5+7 field jets

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,12 @@ gradient, and 7 Hessian components.
 The direct-script examples
 `examples/coil_optimization/optimize_coils_for_external_nearaxis.py` and
 `examples/coil_optimization/optimize_coils_and_external_nearaxis.py` show
-finite-beta stage-two and single-stage optimization, respectively. Parameters
-and output controls are defined at the top of each script; both report the
-three residual blocks and save coils, parameters, and a comparison figure.
+finite-beta stage-two and single-stage optimization, respectively. Both use
+the public database-backed `plasma_stellarator` case with finite pressure,
+exactly zero `I2`, `|iota| > 0.4`, and a nonplanar axis with nonzero torsion.
+Parameters and output controls are defined at the top of each script; both
+report the three residual blocks and save coils, parameters, and a comparison
+figure.
 
 ## Testing
 To run the tests, use `pytest`:

--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ the total field and is intended for vacuum near-axis solutions. The residual
 blocks are smooth, dimensionally normalized least squares with 3 field, 5
 gradient, and 7 Hessian components.
 
+The direct-script examples
+`examples/coil_optimization/optimize_coils_for_external_nearaxis.py` and
+`examples/coil_optimization/optimize_coils_and_external_nearaxis.py` show
+finite-beta stage-two and single-stage optimization, respectively. Parameters
+and output controls are defined at the top of each script; both report the
+three residual blocks and save coils, parameters, and a comparison figure.
+
 ## Testing
 To run the tests, use `pytest`:
 ```sh

--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ ESSOS can be run directly in the command line as `essos`, or by following one of
 python examples/trace_particles_coils_guidingcenter.py
 ```
 
+### Surface-free near-axis field jets
+
+For vacuum or finite-pressure/current near-axis coil design, ESSOS consumes
+the normalized 3+5+7 target provided by pyQSC_JAX:
+
+```python
+from essos.field_jet import (
+    loss_field_jet_coils_near_axis,
+    near_axis_field_jet_target,
+)
+
+target = near_axis_field_jet_target(solution, formal_radius=0.05)
+loss = loss_field_jet_coils_near_axis(coil_field, target)
+```
+
+Supplying `formal_radius` subtracts the plasma-generated field, gradient, and
+Hessian, so the coils match only the external vacuum target. Omitting it uses
+the total field and is intended for vacuum near-axis solutions. The residual
+blocks are smooth, dimensionally normalized least squares with 3 field, 5
+gradient, and 7 Hessian components.
+
 ## Testing
 To run the tests, use `pytest`:
 ```sh
@@ -203,4 +224,3 @@ This project is protected under the MIT License. For more details, refer to the 
 - We acknowledge the help of the whole [UWPlasma](https://rogerio.physics.wisc.edu/) plasma group.
 
 ---
-

--- a/docs/field_jet.rst
+++ b/docs/field_jet.rst
@@ -26,13 +26,18 @@ A vacuum target uses the total near-axis field:
    target = near_axis_field_jet_target(solution)
 
 For finite plasma pressure or current, provide the formal minor radius. ESSOS
-then matches coils to the external vacuum field, not to the total MHD field:
+then matches coils to the external vacuum field, not to the total MHD field.
+The user-facing finite-beta example is a pressure-only stellarator with
+nonzero torsion, not a finite-current tokamak-like channel:
 
 .. code-block:: python
 
+   solution = qsc.solve_configuration("plasma_stellarator", nphi=61)
+   assert solution.inputs.I2 == 0
+   assert solution.inputs.p2 != 0
    target = near_axis_field_jet_target(
        solution,
-       formal_radius=0.05,
+       formal_radius=0.15,
    )
 
 The radius fixes the asymptotic current/flux normalization; no finite-radius
@@ -74,3 +79,9 @@ The initial integration was developed against:
 
 These identifiers document the tested state and are not runtime dependency
 pins.
+
+The focused integration suite additionally checks that the pressure-only
+database case has ``|iota| > 0.4``, RMS torsion above
+``0.5 m^-1``, angle-dependent plasma field, zero enclosed current, and
+nonzero field/Hessian subtraction. Both direct optimization scripts are run
+from a clean working directory.

--- a/docs/field_jet.rst
+++ b/docs/field_jet.rst
@@ -1,0 +1,76 @@
+Near-axis external field jets
+=============================
+
+ESSOS consumes the surface-free field-jet targets produced by pyQSC_JAX.
+The dependency direction is one way: pyQSC_JAX computes the near-axis
+equilibrium and ESSOS evaluates the coil field.
+
+Target construction
+-------------------
+
+A vacuum target uses the total near-axis field:
+
+.. code-block:: python
+
+   import pyqsc_jax as qsc
+   from essos.field_jet import near_axis_field_jet_target
+
+   solution = qsc.Qsc(
+       rc=[1.0, 0.155, 0.0102],
+       zs=[0.0, 0.154, 0.0111],
+       nfp=2,
+       etabar=0.64,
+       B2c=-0.00322,
+       order="r2",
+   )
+   target = near_axis_field_jet_target(solution)
+
+For finite plasma pressure or current, provide the formal minor radius. ESSOS
+then matches coils to the external vacuum field, not to the total MHD field:
+
+.. code-block:: python
+
+   target = near_axis_field_jet_target(
+       solution,
+       formal_radius=0.05,
+   )
+
+The radius fixes the asymptotic current/flux normalization; no finite-radius
+surface is constructed. The legacy
+``pyqsc_jax.near_axis.near_axis`` adapter is also accepted.
+
+Normalized objective
+--------------------
+
+``normalized_field_jet_residuals`` evaluates
+
+.. math::
+
+   r_0 &= (B_{\mathrm{coils}}-B_c)/B_{\mathrm{ref}},\\
+   r_1 &= L_{\mathrm{ref}}\,
+          \operatorname{STF}_2(\nabla B_{\mathrm{coils}}-D_c)
+          /B_{\mathrm{ref}},\\
+   r_2 &= L_{\mathrm{ref}}^2\,
+          \operatorname{STF}_3(\nabla\nabla B_{\mathrm{coils}}-H_c)
+          /B_{\mathrm{ref}}.
+
+The returned blocks have 3, 5, and 7 components per axis point.
+``loss_field_jet_coils_near_axis`` forms a weighted sum of their mean squares.
+It is smooth and differentiable with respect to coil shapes, coil currents,
+axis Fourier coefficients, and near-axis physics inputs.
+
+ESSOS obtains the coil Hessian from ``MagneticField.d2B_by_dXdX`` using nested
+JAX differentiation. pyQSC_JAX owns the STF projection and component ordering,
+so the tensor convention is not duplicated between packages.
+
+Validation provenance
+---------------------
+
+The initial integration was developed against:
+
+* pyQSC_JAX commit ``c7277fc``;
+* ESSOS base commit ``240fe64``; and
+* the merged near-axis extraction PR commit ``448356f``.
+
+These identifiers document the tested state and are not runtime dependency
+pins.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,3 +25,4 @@ stellarator coils to improve plasma confinement.
    :caption: Contents:
 
    getting_started
+   field_jet

--- a/essos/field_jet.py
+++ b/essos/field_jet.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import Any
 
 import jax

--- a/essos/field_jet.py
+++ b/essos/field_jet.py
@@ -1,0 +1,169 @@
+"""Normalized coil objectives for near-axis vacuum field jets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from pyqsc_jax import (
+    pack_symmetric_trace_free_rank2,
+    pack_symmetric_trace_free_rank3,
+)
+
+ArrayLike = Any
+
+
+def _positive_scalar(value: ArrayLike, *, name: str) -> jax.Array:
+    value = jnp.asarray(value)
+    if value.ndim:
+        raise ValueError(f"{name} must be a scalar.")
+    try:
+        if bool(value <= 0):
+            raise ValueError(f"{name} must be positive.")
+    except jax.errors.TracerBoolConversionError:
+        pass
+    return value
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class NearAxisFieldJetTarget:
+    """Immutable 3+5+7 vacuum target sampled on a magnetic axis."""
+
+    points: jax.Array
+    field: jax.Array
+    gradient: jax.Array
+    hessian: jax.Array
+    gradient_independent: jax.Array
+    hessian_independent: jax.Array
+    reference_field: jax.Array
+    reference_length: jax.Array
+    is_external: bool = dataclass_field(metadata={"static": True})
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class FieldJetResiduals:
+    """Dimensionless field, gradient, and Hessian residual blocks."""
+
+    field: jax.Array
+    gradient: jax.Array
+    hessian: jax.Array
+
+
+def near_axis_field_jet_target(
+    near_axis,
+    *,
+    formal_radius: ArrayLike | None = None,
+    reference_field: ArrayLike | None = None,
+    reference_length: ArrayLike | None = None,
+    angular_resolution: int = 128,
+) -> NearAxisFieldJetTarget:
+    """Construct a total-vacuum or surface-free external 3+5+7 target.
+
+    ``formal_radius=None`` uses the total near-axis jet and is intended for a
+    vacuum solution. Supplying a positive formal radius subtracts the plasma
+    field, gradient, and Hessian before constructing the coil target.
+    """
+
+    solution = getattr(near_axis, "solution", near_axis)
+    if solution.field_jet is None:
+        raise ValueError("A field-jet target requires an r2 or r3 near-axis solution.")
+
+    points = solution.geometry.position_cartesian
+    if formal_radius is None:
+        target_field = solution.B_axis
+        target_gradient = solution.grad_B_axis
+        target_hessian = solution.grad_grad_B_axis
+        is_external = False
+    else:
+        from pyqsc_jax import plasma_hessian_on_axis
+
+        external = plasma_hessian_on_axis(
+            solution,
+            formal_radius=formal_radius,
+            angular_resolution=angular_resolution,
+        )
+        target_field = external.field.external_field
+        target_gradient = external.field.external_gradient
+        target_hessian = external.external_hessian
+        is_external = True
+
+    if reference_field is None:
+        reference_field = solution.inputs.B0
+    if reference_length is None:
+        reference_length = solution.geometry.abs_G0_over_B0
+
+    return NearAxisFieldJetTarget(
+        points=points,
+        field=target_field,
+        gradient=target_gradient,
+        hessian=target_hessian,
+        gradient_independent=pack_symmetric_trace_free_rank2(target_gradient),
+        hessian_independent=pack_symmetric_trace_free_rank3(target_hessian),
+        reference_field=_positive_scalar(reference_field, name="reference_field"),
+        reference_length=_positive_scalar(reference_length, name="reference_length"),
+        is_external=is_external,
+    )
+
+
+def normalized_field_jet_residuals(
+    coil_field,
+    target: NearAxisFieldJetTarget,
+) -> FieldJetResiduals:
+    """Evaluate dimensionless 3+5+7 residual blocks for a coil field."""
+
+    coil_values = jax.vmap(coil_field.B)(target.points)
+    coil_gradients = jax.vmap(coil_field.dB_by_dX)(target.points)
+    coil_hessians = jax.vmap(coil_field.d2B_by_dXdX)(target.points)
+    return FieldJetResiduals(
+        field=(coil_values - target.field) / target.reference_field,
+        gradient=(
+            target.reference_length
+            * (
+                pack_symmetric_trace_free_rank2(coil_gradients)
+                - target.gradient_independent
+            )
+            / target.reference_field
+        ),
+        hessian=(
+            target.reference_length**2
+            * (
+                pack_symmetric_trace_free_rank3(coil_hessians)
+                - target.hessian_independent
+            )
+            / target.reference_field
+        ),
+    )
+
+
+def field_jet_loss_terms(
+    coil_field,
+    target: NearAxisFieldJetTarget,
+) -> jax.Array:
+    """Return mean-square ``(field, gradient, Hessian)`` objective terms."""
+
+    residuals = normalized_field_jet_residuals(coil_field, target)
+    return jnp.stack(
+        (
+            jnp.mean(jnp.square(residuals.field)),
+            jnp.mean(jnp.square(residuals.gradient)),
+            jnp.mean(jnp.square(residuals.hessian)),
+        )
+    )
+
+
+def loss_field_jet_coils_near_axis(
+    coil_field,
+    target: NearAxisFieldJetTarget,
+    *,
+    weights: ArrayLike = (1.0, 1.0, 1.0),
+) -> jax.Array:
+    """Return a smooth weighted least-squares loss for a near-axis field jet."""
+
+    weights = jnp.asarray(weights)
+    if weights.shape != (3,):
+        raise ValueError("weights must have shape (3,).")
+    return jnp.dot(weights, field_jet_loss_terms(coil_field, target))

--- a/essos/fields.py
+++ b/essos/fields.py
@@ -36,7 +36,13 @@ class MagneticField():
     @jit
     def dB_by_dX(self, points):
         return jacfwd(self.B)(points)
-    
+
+    @jit
+    def d2B_by_dXdX(self, points):
+        """Return ``d² B_i / (d X_j d X_k)`` in Cartesian coordinates."""
+
+        return jacfwd(self.dB_by_dX)(points)
+
     @jit
     def dAbsB_by_dX(self, points):
         return grad(self.AbsB)(points)
@@ -69,7 +75,19 @@ class BiotSavart(MagneticField):
         self.coils = coils
         self._r_axis = None
         self._z_axis = None
-    
+
+    @property
+    def currents(self):
+        return self.coils.currents
+
+    @property
+    def gamma(self):
+        return self.coils.gamma
+
+    @property
+    def gamma_dash(self):
+        return self.coils.gamma_dash
+
     @property
     def dofs(self):
         return self.coils.dofs
@@ -396,4 +414,3 @@ class near_axis:
             "Please run 'pip install git+https://github.com/uwplasma/pyQSC_JAX.git' "
             "and import it via 'from pyqsc_jax.near_axis import near_axis'."
         )
-    

--- a/examples/coil_optimization/optimize_coils_and_external_nearaxis.py
+++ b/examples/coil_optimization/optimize_coils_and_external_nearaxis.py
@@ -1,0 +1,258 @@
+"""Single-stage finite-beta optimization of a near-axis target and its coils."""
+
+import json
+from pathlib import Path
+from time import perf_counter
+
+import jax
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import numpy as np
+import pyqsc_jax as qsc
+from jax.flatten_util import ravel_pytree
+
+from essos.coils import Coils, CreateEquallySpacedCurves
+from essos.field_jet import (
+    field_jet_loss_terms,
+    loss_field_jet_coils_near_axis,
+    near_axis_field_jet_target,
+)
+from essos.fields import BiotSavart
+
+# Near-axis parameters and bounded single-stage variables:
+# (rc[1], zs[1], etabar, B2c, I2)
+INITIAL_NEAR_AXIS_VARIABLES = jnp.asarray([0.09, -0.09, 0.95, -0.7, 0.9])
+LOWER_NEAR_AXIS_BOUNDS = jnp.asarray([0.06, -0.12, 0.75, -1.0, 0.5])
+UPPER_NEAR_AXIS_BOUNDS = jnp.asarray([0.12, -0.06, 1.15, -0.3, 1.2])
+NFP = 2
+P2 = -600000.0
+NPHI = 15
+FORMAL_RADIUS = 0.05
+IOTA_TARGET = 0.8
+
+# Coil and objective parameters
+N_BASE_COILS = 2
+COIL_ORDER = 2
+COIL_SEGMENTS = 24
+INITIAL_CURRENT = 1.5e6
+FIELD_JET_WEIGHTS = jnp.asarray([1.0, 1.0, 0.25])
+IOTA_WEIGHT = 0.05
+B20_WEIGHT = 1.0e-4
+LENGTH_WEIGHT = 1.0e-3
+CURVATURE_WEIGHT = 1.0e-4
+CURRENT_WEIGHT = 1.0e-5
+MAXIMUM_COIL_LENGTH = 5.0
+MAXIMUM_COIL_CURVATURE = 10.0
+OPTIMIZATION_STEPS = 3
+INITIAL_STEP_SIZE = 0.03
+BACKTRACKING_STEPS = 8
+
+# Output controls
+SAVE_OUTPUT = True
+SHOW_FIGURE = False
+OUTPUT_DIRECTORY = Path("examples/output_files/external_nearaxis_single_stage")
+
+initial_curves = CreateEquallySpacedCurves(
+    n_curves=N_BASE_COILS,
+    order=COIL_ORDER,
+    R=1.0,
+    r=0.5,
+    n_segments=COIL_SEGMENTS,
+    nfp=NFP,
+    stellsym=True,
+)
+initial_coils = Coils(
+    curves=initial_curves,
+    currents=jnp.full(N_BASE_COILS, INITIAL_CURRENT),
+)
+initial_coil_vector, unravel_coils = ravel_pytree(initial_coils)
+number_coil_variables = initial_coil_vector.size
+initial_vector = jnp.concatenate((initial_coil_vector, INITIAL_NEAR_AXIS_VARIABLES))
+
+
+def solve_near_axis(variables):
+    rc1, zs1, etabar, B2c, I2 = variables
+    return qsc.Qsc(
+        rc=jnp.stack((jnp.asarray(1.0), rc1)),
+        zs=jnp.stack((jnp.asarray(0.0), zs1)),
+        nfp=NFP,
+        etabar=etabar,
+        I2=I2,
+        p2=P2,
+        B2c=B2c,
+        nphi=NPHI,
+        order="r2",
+    )
+
+
+def engineering_loss(coils):
+    length_excess = jnp.maximum(coils.length / MAXIMUM_COIL_LENGTH - 1, 0)
+    curvature_excess = jnp.maximum(
+        coils.curvature / MAXIMUM_COIL_CURVATURE - 1,
+        0,
+    )
+    return (
+        LENGTH_WEIGHT * jnp.mean(jnp.square(length_excess))
+        + CURVATURE_WEIGHT * jnp.mean(jnp.square(curvature_excess))
+        + CURRENT_WEIGHT * jnp.mean(jnp.square(coils.dofs_currents))
+    )
+
+
+def objective(vector):
+    coils = unravel_coils(vector[:number_coil_variables])
+    solution = solve_near_axis(vector[number_coil_variables:])
+    target = near_axis_field_jet_target(
+        solution,
+        formal_radius=FORMAL_RADIUS,
+        angular_resolution=32,
+    )
+    field_jet_loss = loss_field_jet_coils_near_axis(
+        BiotSavart(coils),
+        target,
+        weights=FIELD_JET_WEIGHTS,
+    )
+    iota_loss = IOTA_WEIGHT * jnp.square((solution.iota - IOTA_TARGET) / IOTA_TARGET)
+    b20_loss = B20_WEIGHT * jnp.square(solution.B20_residual)
+    return field_jet_loss + iota_loss + b20_loss + engineering_loss(coils)
+
+
+value_and_gradient = jax.jit(jax.value_and_grad(objective))
+objective_compiled = jax.jit(objective)
+optimization_vector = initial_vector
+initial_loss = float(objective_compiled(optimization_vector))
+initial_solution = solve_near_axis(INITIAL_NEAR_AXIS_VARIABLES)
+initial_target = near_axis_field_jet_target(
+    initial_solution,
+    formal_radius=FORMAL_RADIUS,
+    angular_resolution=32,
+)
+print("initial objective:", initial_loss)
+print("initial iota:", float(initial_solution.iota))
+print("initial B20 residual:", float(initial_solution.B20_residual))
+
+start_time = perf_counter()
+for iteration in range(OPTIMIZATION_STEPS):
+    value, gradient = value_and_gradient(optimization_vector)
+    coil_gradient = gradient[:number_coil_variables]
+    near_axis_gradient = gradient[number_coil_variables:]
+    direction = jnp.concatenate(
+        (
+            -coil_gradient / jnp.maximum(jnp.linalg.norm(coil_gradient), 1.0e-14),
+            -near_axis_gradient
+            / jnp.maximum(jnp.linalg.norm(near_axis_gradient), 1.0e-14),
+        )
+    )
+    step_size = INITIAL_STEP_SIZE
+    accepted = False
+    for _ in range(BACKTRACKING_STEPS):
+        candidate = optimization_vector + step_size * direction
+        bounded_near_axis = jnp.clip(
+            candidate[number_coil_variables:],
+            LOWER_NEAR_AXIS_BOUNDS,
+            UPPER_NEAR_AXIS_BOUNDS,
+        )
+        candidate = candidate.at[number_coil_variables:].set(bounded_near_axis)
+        candidate_value = objective_compiled(candidate)
+        if float(candidate_value) < float(value):
+            optimization_vector = candidate
+            accepted = True
+            break
+        step_size *= 0.5
+    print(
+        f"iteration {iteration + 1}: loss={float(value):.6e}, "
+        f"step={step_size:.3e}, accepted={accepted}"
+    )
+    if not accepted:
+        break
+
+optimized_coils = unravel_coils(optimization_vector[:number_coil_variables])
+optimized_near_axis_variables = optimization_vector[number_coil_variables:]
+optimized_solution = solve_near_axis(optimized_near_axis_variables)
+optimized_target = near_axis_field_jet_target(
+    optimized_solution,
+    formal_radius=FORMAL_RADIUS,
+    angular_resolution=32,
+)
+optimized_field = BiotSavart(optimized_coils)
+final_loss = float(objective_compiled(optimization_vector))
+initial_terms = np.asarray(
+    field_jet_loss_terms(BiotSavart(initial_coils), initial_target)
+)
+final_terms = np.asarray(field_jet_loss_terms(optimized_field, optimized_target))
+print("optimization seconds:", perf_counter() - start_time)
+print("final objective:", final_loss)
+print(
+    "final near-axis variables (rc1, zs1, etabar, B2c, I2):",
+    np.asarray(optimized_near_axis_variables),
+)
+print("final iota:", float(optimized_solution.iota))
+print("final B20 residual:", float(optimized_solution.B20_residual))
+print("initial (B, grad-B, Hessian) terms:", initial_terms)
+print("final (B, grad-B, Hessian) terms:", final_terms)
+
+figure = plt.figure(figsize=(10, 4))
+axis_3d = figure.add_subplot(1, 2, 1, projection="3d")
+axis_3d.plot(
+    np.asarray(initial_target.points[:, 0]),
+    np.asarray(initial_target.points[:, 1]),
+    np.asarray(initial_target.points[:, 2]),
+    color="tab:gray",
+    linewidth=2,
+    label="initial axis",
+)
+axis_3d.plot(
+    np.asarray(optimized_target.points[:, 0]),
+    np.asarray(optimized_target.points[:, 1]),
+    np.asarray(optimized_target.points[:, 2]),
+    color="black",
+    linewidth=2,
+    label="optimized axis",
+)
+for index, curve in enumerate(np.asarray(optimized_coils.gamma)):
+    axis_3d.plot(
+        curve[:, 0],
+        curve[:, 1],
+        curve[:, 2],
+        color="tab:blue",
+        label="optimized coils" if index == 0 else None,
+    )
+axis_3d.set_box_aspect((1, 1, 1))
+axis_3d.legend()
+
+axis_loss = figure.add_subplot(1, 2, 2)
+locations = np.arange(3)
+axis_loss.bar(locations - 0.18, initial_terms, width=0.36, label="initial")
+axis_loss.bar(locations + 0.18, final_terms, width=0.36, label="optimized")
+axis_loss.set_xticks(locations, ("B", "grad B", "Hessian"))
+axis_loss.set_yscale("log")
+axis_loss.set_ylabel("mean-square normalized residual")
+axis_loss.legend()
+figure.tight_layout()
+
+if SAVE_OUTPUT:
+    OUTPUT_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    optimized_coils.to_json(OUTPUT_DIRECTORY / "optimized_coils.json")
+    near_axis_output = {
+        "rc": [1.0, float(optimized_near_axis_variables[0])],
+        "zs": [0.0, float(optimized_near_axis_variables[1])],
+        "etabar": float(optimized_near_axis_variables[2]),
+        "B2c": float(optimized_near_axis_variables[3]),
+        "I2": float(optimized_near_axis_variables[4]),
+        "p2": P2,
+        "iota": float(optimized_solution.iota),
+        "formal_radius": FORMAL_RADIUS,
+    }
+    (OUTPUT_DIRECTORY / "optimized_near_axis.json").write_text(
+        json.dumps(near_axis_output, indent=2) + "\n"
+    )
+    figure.savefig(
+        OUTPUT_DIRECTORY / "single_stage_external_field_jet.png",
+        dpi=180,
+        bbox_inches="tight",
+    )
+    print("saved outputs to:", OUTPUT_DIRECTORY)
+
+if SHOW_FIGURE:
+    plt.show()
+else:
+    plt.close(figure)

--- a/examples/coil_optimization/optimize_coils_and_external_nearaxis.py
+++ b/examples/coil_optimization/optimize_coils_and_external_nearaxis.py
@@ -20,15 +20,21 @@ from essos.field_jet import (
 from essos.fields import BiotSavart
 
 # Near-axis parameters and bounded single-stage variables:
-# (rc[1], zs[1], etabar, B2c, I2)
-INITIAL_NEAR_AXIS_VARIABLES = jnp.asarray([0.09, -0.09, 0.95, -0.7, 0.9])
-LOWER_NEAR_AXIS_BOUNDS = jnp.asarray([0.06, -0.12, 0.75, -1.0, 0.5])
-UPPER_NEAR_AXIS_BOUNDS = jnp.asarray([0.12, -0.06, 1.15, -0.3, 1.2])
-NFP = 2
-P2 = -600000.0
+# (rc[1], zs[1], etabar, B2c). I2 remains exactly zero.
+CONFIGURATION = "plasma_stellarator"
+BASE_RC = jnp.asarray([1.0, -0.5415884, 0.029195854, 0.0048646266])
+BASE_ZS = jnp.asarray([0.0, -0.57113713, 0.029922731, 0.0041398546])
+INITIAL_NEAR_AXIS_VARIABLES = jnp.asarray(
+    [-0.5415884, -0.57113713, 1.1396117, -0.050057083]
+)
+LOWER_NEAR_AXIS_BOUNDS = jnp.asarray([-0.57, -0.60, 0.95, -0.20])
+UPPER_NEAR_AXIS_BOUNDS = jnp.asarray([-0.51, -0.54, 1.30, 0.10])
+NFP = 4
+I2 = 0.0
+P2 = -28248.188
 NPHI = 15
-FORMAL_RADIUS = 0.05
-IOTA_TARGET = 0.8
+FORMAL_RADIUS = 0.15
+IOTA_TARGET = -2.8
 
 # Coil and objective parameters
 N_BASE_COILS = 2
@@ -68,13 +74,17 @@ initial_coils = Coils(
 initial_coil_vector, unravel_coils = ravel_pytree(initial_coils)
 number_coil_variables = initial_coil_vector.size
 initial_vector = jnp.concatenate((initial_coil_vector, INITIAL_NEAR_AXIS_VARIABLES))
+reference_configuration = qsc.get_configuration(CONFIGURATION)
+print("source:", reference_configuration.source_url)
 
 
 def solve_near_axis(variables):
-    rc1, zs1, etabar, B2c, I2 = variables
+    rc1, zs1, etabar, B2c = variables
+    rc = BASE_RC.at[1].set(rc1)
+    zs = BASE_ZS.at[1].set(zs1)
     return qsc.Qsc(
-        rc=jnp.stack((jnp.asarray(1.0), rc1)),
-        zs=jnp.stack((jnp.asarray(0.0), zs1)),
+        rc=rc,
+        zs=zs,
         nfp=NFP,
         etabar=etabar,
         I2=I2,
@@ -129,6 +139,8 @@ initial_target = near_axis_field_jet_target(
 print("initial objective:", initial_loss)
 print("initial iota:", float(initial_solution.iota))
 print("initial B20 residual:", float(initial_solution.B20_residual))
+assert initial_solution.inputs.I2 == 0
+assert initial_solution.inputs.p2 != 0
 
 start_time = perf_counter()
 for iteration in range(OPTIMIZATION_STEPS):
@@ -182,11 +194,24 @@ final_terms = np.asarray(field_jet_loss_terms(optimized_field, optimized_target)
 print("optimization seconds:", perf_counter() - start_time)
 print("final objective:", final_loss)
 print(
-    "final near-axis variables (rc1, zs1, etabar, B2c, I2):",
+    "final near-axis variables (rc1, zs1, etabar, B2c):",
     np.asarray(optimized_near_axis_variables),
 )
 print("final iota:", float(optimized_solution.iota))
 print("final B20 residual:", float(optimized_solution.B20_residual))
+optimized_torsion_rms = jnp.sqrt(
+    jnp.sum(optimized_solution.torsion**2 * optimized_solution.geometry.d_l_d_phi)
+    / jnp.sum(optimized_solution.geometry.d_l_d_phi)
+)
+assert optimized_solution.inputs.I2 == 0
+assert jnp.abs(optimized_solution.iota) > 0.4
+assert optimized_torsion_rms > 0.5
+print(
+    "final I2, p2:",
+    float(optimized_solution.inputs.I2),
+    float(optimized_solution.inputs.p2),
+)
+print("final RMS axis torsion:", float(optimized_torsion_rms))
 print("initial (B, grad-B, Hessian) terms:", initial_terms)
 print("final (B, grad-B, Hessian) terms:", final_terms)
 
@@ -232,15 +257,20 @@ figure.tight_layout()
 if SAVE_OUTPUT:
     OUTPUT_DIRECTORY.mkdir(parents=True, exist_ok=True)
     optimized_coils.to_json(OUTPUT_DIRECTORY / "optimized_coils.json")
+    optimized_rc = BASE_RC.at[1].set(optimized_near_axis_variables[0])
+    optimized_zs = BASE_ZS.at[1].set(optimized_near_axis_variables[1])
     near_axis_output = {
-        "rc": [1.0, float(optimized_near_axis_variables[0])],
-        "zs": [0.0, float(optimized_near_axis_variables[1])],
+        "rc": np.asarray(optimized_rc).tolist(),
+        "zs": np.asarray(optimized_zs).tolist(),
         "etabar": float(optimized_near_axis_variables[2]),
         "B2c": float(optimized_near_axis_variables[3]),
-        "I2": float(optimized_near_axis_variables[4]),
+        "I2": I2,
         "p2": P2,
         "iota": float(optimized_solution.iota),
+        "torsion_rms": float(optimized_torsion_rms),
         "formal_radius": FORMAL_RADIUS,
+        "source_database_id": reference_configuration.source_database_id,
+        "source_url": reference_configuration.source_url,
     }
     (OUTPUT_DIRECTORY / "optimized_near_axis.json").write_text(
         json.dumps(near_axis_output, indent=2) + "\n"

--- a/examples/coil_optimization/optimize_coils_for_external_nearaxis.py
+++ b/examples/coil_optimization/optimize_coils_for_external_nearaxis.py
@@ -1,0 +1,209 @@
+"""Stage-two finite-beta coil optimization against a surface-free field jet."""
+
+from pathlib import Path
+from time import perf_counter
+
+import jax
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+import numpy as np
+import pyqsc_jax as qsc
+from jax.flatten_util import ravel_pytree
+
+from essos.coils import Coils, CreateEquallySpacedCurves
+from essos.field_jet import (
+    field_jet_loss_terms,
+    loss_field_jet_coils_near_axis,
+    near_axis_field_jet_target,
+)
+from essos.fields import BiotSavart
+
+# Near-axis parameters
+RC = [1.0, 0.09]
+ZS = [0.0, -0.09]
+NFP = 2
+ETABAR = 0.95
+I2 = 0.9
+P2 = -600000.0
+B2C = -0.7
+NPHI = 15
+FORMAL_RADIUS = 0.05
+
+# Coil and optimization parameters
+N_BASE_COILS = 2
+COIL_ORDER = 2
+COIL_SEGMENTS = 24
+COIL_MAJOR_RADIUS = 1.0
+COIL_MINOR_RADIUS = 0.5
+INITIAL_CURRENT = 1.5e6
+FIELD_JET_WEIGHTS = jnp.asarray([1.0, 1.0, 0.25])
+LENGTH_WEIGHT = 1.0e-3
+CURVATURE_WEIGHT = 1.0e-4
+CURRENT_WEIGHT = 1.0e-5
+MAXIMUM_COIL_LENGTH = 5.0
+MAXIMUM_COIL_CURVATURE = 10.0
+OPTIMIZATION_STEPS = 4
+INITIAL_STEP_SIZE = 0.05
+BACKTRACKING_STEPS = 8
+
+# Output controls
+SAVE_OUTPUT = True
+SHOW_FIGURE = False
+OUTPUT_DIRECTORY = Path("examples/output_files/external_nearaxis_stage_two")
+
+print("Solving the fixed finite-pressure/current near-axis target...")
+solution = qsc.Qsc(
+    rc=RC,
+    zs=ZS,
+    nfp=NFP,
+    etabar=ETABAR,
+    I2=I2,
+    p2=P2,
+    B2c=B2C,
+    nphi=NPHI,
+    order="r2",
+)
+target = near_axis_field_jet_target(
+    solution,
+    formal_radius=FORMAL_RADIUS,
+    angular_resolution=64,
+)
+print("iota:", float(solution.iota))
+print(
+    "external target shapes:",
+    target.field.shape,
+    target.gradient_independent.shape,
+    target.hessian_independent.shape,
+)
+
+initial_curves = CreateEquallySpacedCurves(
+    n_curves=N_BASE_COILS,
+    order=COIL_ORDER,
+    R=COIL_MAJOR_RADIUS,
+    r=COIL_MINOR_RADIUS,
+    n_segments=COIL_SEGMENTS,
+    nfp=NFP,
+    stellsym=True,
+)
+initial_coils = Coils(
+    curves=initial_curves,
+    currents=jnp.full(N_BASE_COILS, INITIAL_CURRENT),
+)
+initial_vector, unravel_coils = ravel_pytree(initial_coils)
+
+
+def engineering_loss(coils):
+    length_excess = jnp.maximum(coils.length / MAXIMUM_COIL_LENGTH - 1, 0)
+    curvature_excess = jnp.maximum(
+        coils.curvature / MAXIMUM_COIL_CURVATURE - 1,
+        0,
+    )
+    normalized_current = coils.dofs_currents
+    return (
+        LENGTH_WEIGHT * jnp.mean(jnp.square(length_excess))
+        + CURVATURE_WEIGHT * jnp.mean(jnp.square(curvature_excess))
+        + CURRENT_WEIGHT * jnp.mean(jnp.square(normalized_current))
+    )
+
+
+def objective(coil_vector):
+    coils = unravel_coils(coil_vector)
+    coil_field = BiotSavart(coils)
+    return loss_field_jet_coils_near_axis(
+        coil_field,
+        target,
+        weights=FIELD_JET_WEIGHTS,
+    ) + engineering_loss(coils)
+
+
+value_and_gradient = jax.jit(jax.value_and_grad(objective))
+objective_compiled = jax.jit(objective)
+coil_vector = initial_vector
+initial_loss = float(objective_compiled(coil_vector))
+print("initial normalized objective:", initial_loss)
+
+start_time = perf_counter()
+for iteration in range(OPTIMIZATION_STEPS):
+    value, gradient = value_and_gradient(coil_vector)
+    direction = -gradient / jnp.maximum(jnp.linalg.norm(gradient), 1.0e-14)
+    step_size = INITIAL_STEP_SIZE
+    accepted = False
+    for _ in range(BACKTRACKING_STEPS):
+        candidate = coil_vector + step_size * direction
+        candidate_value = objective_compiled(candidate)
+        if float(candidate_value) < float(value):
+            coil_vector = candidate
+            accepted = True
+            break
+        step_size *= 0.5
+    print(
+        f"iteration {iteration + 1}: loss={float(value):.6e}, "
+        f"step={step_size:.3e}, accepted={accepted}"
+    )
+    if not accepted:
+        break
+
+optimized_coils = unravel_coils(coil_vector)
+optimized_field = BiotSavart(optimized_coils)
+final_loss = float(objective_compiled(coil_vector))
+initial_terms = np.asarray(field_jet_loss_terms(BiotSavart(initial_coils), target))
+final_terms = np.asarray(field_jet_loss_terms(optimized_field, target))
+print("optimization seconds:", perf_counter() - start_time)
+print("final normalized objective:", final_loss)
+print("initial (B, grad-B, Hessian) terms:", initial_terms)
+print("final (B, grad-B, Hessian) terms:", final_terms)
+
+figure = plt.figure(figsize=(10, 4))
+axis_3d = figure.add_subplot(1, 2, 1, projection="3d")
+axis_3d.plot(
+    np.asarray(target.points[:, 0]),
+    np.asarray(target.points[:, 1]),
+    np.asarray(target.points[:, 2]),
+    color="black",
+    linewidth=2,
+    label="magnetic axis",
+)
+for index, curve in enumerate(np.asarray(initial_coils.gamma)):
+    axis_3d.plot(
+        curve[:, 0],
+        curve[:, 1],
+        curve[:, 2],
+        color="tab:gray",
+        alpha=0.35,
+        label="initial coils" if index == 0 else None,
+    )
+for index, curve in enumerate(np.asarray(optimized_coils.gamma)):
+    axis_3d.plot(
+        curve[:, 0],
+        curve[:, 1],
+        curve[:, 2],
+        color="tab:blue",
+        label="optimized coils" if index == 0 else None,
+    )
+axis_3d.set_box_aspect((1, 1, 1))
+axis_3d.legend()
+
+axis_loss = figure.add_subplot(1, 2, 2)
+locations = np.arange(3)
+axis_loss.bar(locations - 0.18, initial_terms, width=0.36, label="initial")
+axis_loss.bar(locations + 0.18, final_terms, width=0.36, label="optimized")
+axis_loss.set_xticks(locations, ("B", "grad B", "Hessian"))
+axis_loss.set_yscale("log")
+axis_loss.set_ylabel("mean-square normalized residual")
+axis_loss.legend()
+figure.tight_layout()
+
+if SAVE_OUTPUT:
+    OUTPUT_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    optimized_coils.to_json(OUTPUT_DIRECTORY / "optimized_coils.json")
+    figure.savefig(
+        OUTPUT_DIRECTORY / "stage_two_external_field_jet.png",
+        dpi=180,
+        bbox_inches="tight",
+    )
+    print("saved outputs to:", OUTPUT_DIRECTORY)
+
+if SHOW_FIGURE:
+    plt.show()
+else:
+    plt.close(figure)

--- a/examples/coil_optimization/optimize_coils_for_external_nearaxis.py
+++ b/examples/coil_optimization/optimize_coils_for_external_nearaxis.py
@@ -19,15 +19,9 @@ from essos.field_jet import (
 from essos.fields import BiotSavart
 
 # Near-axis parameters
-RC = [1.0, 0.09]
-ZS = [0.0, -0.09]
-NFP = 2
-ETABAR = 0.95
-I2 = 0.9
-P2 = -600000.0
-B2C = -0.7
+CONFIGURATION = "plasma_stellarator"
 NPHI = 15
-FORMAL_RADIUS = 0.05
+FORMAL_RADIUS = 0.15
 
 # Coil and optimization parameters
 N_BASE_COILS = 2
@@ -51,24 +45,27 @@ SAVE_OUTPUT = True
 SHOW_FIGURE = False
 OUTPUT_DIRECTORY = Path("examples/output_files/external_nearaxis_stage_two")
 
-print("Solving the fixed finite-pressure/current near-axis target...")
-solution = qsc.Qsc(
-    rc=RC,
-    zs=ZS,
-    nfp=NFP,
-    etabar=ETABAR,
-    I2=I2,
-    p2=P2,
-    B2c=B2C,
-    nphi=NPHI,
-    order="r2",
-)
+print("Solving the fixed pressure-only stellarator target...")
+configuration = qsc.get_configuration(CONFIGURATION)
+solution = configuration.solve(nphi=NPHI, order="r2")
+NFP = configuration.nfp
 target = near_axis_field_jet_target(
     solution,
     formal_radius=FORMAL_RADIUS,
     angular_resolution=64,
 )
+torsion_rms = jnp.sqrt(
+    jnp.sum(solution.torsion**2 * solution.geometry.d_l_d_phi)
+    / jnp.sum(solution.geometry.d_l_d_phi)
+)
+assert solution.inputs.I2 == 0
+assert solution.inputs.p2 != 0
+assert jnp.abs(solution.iota) > 0.4
+assert torsion_rms > 0.5
+print("source:", configuration.source_url)
 print("iota:", float(solution.iota))
+print("I2, p2:", float(solution.inputs.I2), float(solution.inputs.p2))
+print("RMS axis torsion:", float(torsion_rms))
 print(
     "external target shapes:",
     target.field.shape,

--- a/tests/test_field_jet.py
+++ b/tests/test_field_jet.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import pyqsc_jax as qsc
+from jax.flatten_util import ravel_pytree
 from essos.coils import Coils, Curves
 from essos.field_jet import (
     FieldJetResiduals,
@@ -300,6 +301,35 @@ def test_finite_current_objective_has_axis_and_near_axis_gradients():
         rtol=1.0e-6,
         atol=1.0e-7,
     )
+
+
+def test_vacuum_coil_optimization_step_reduces_objective():
+    target = near_axis_field_jet_target(_vacuum_solution(nphi=15))
+    dofs = jnp.zeros((1, 3, 3))
+    dofs = dofs.at[0, 0, 0].set(1.0)
+    dofs = dofs.at[0, 0, 2].set(0.45)
+    dofs = dofs.at[0, 2, 1].set(-0.45)
+    initial_coils = Coils(
+        Curves(dofs, n_segments=24, nfp=2, stellsym=True),
+        jnp.asarray([1.0e6]),
+    )
+    initial_vector, unravel = ravel_pytree(initial_coils)
+
+    def objective(vector):
+        return loss_field_jet_coils_near_axis(
+            BiotSavart(unravel(vector)),
+            target,
+        )
+
+    initial_value, gradient = jax.value_and_grad(objective)(initial_vector)
+    direction = -gradient / jnp.linalg.norm(gradient)
+    candidate_values = jnp.stack(
+        tuple(
+            objective(initial_vector + step * direction) for step in (0.05, 0.01, 0.002)
+        )
+    )
+
+    assert jnp.min(candidate_values) < initial_value
 
 
 def test_target_and_weight_guards():

--- a/tests/test_field_jet.py
+++ b/tests/test_field_jet.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import numpy as np
-import pytest
-
 import pyqsc_jax as qsc
+import pytest
 from jax.flatten_util import ravel_pytree
+
 from essos.coils import Coils, Curves
 from essos.field_jet import (
     FieldJetResiduals,
@@ -104,6 +104,10 @@ def _finite_current_solution(nphi=31):
     )
 
 
+def _pressure_only_stellarator_solution(nphi=31):
+    return qsc.solve_configuration("plasma_stellarator", nphi=nphi, order="r2")
+
+
 def test_magnetic_field_hessian_matches_polynomial_coefficients():
     field = PolynomialField(jnp.asarray([0.2, -0.1, 0.4]))
     point = jnp.asarray([0.8, 0.1, -0.2])
@@ -191,6 +195,29 @@ def test_finite_current_target_uses_external_not_total_field_jet():
     assert external.hessian_independent.shape == (61, 7)
     assert np.max(np.abs(np.asarray(external.field - total.field))) > 1.0e-6
     assert np.max(np.abs(np.asarray(external.gradient - total.gradient))) > 1.0e-3
+    assert np.max(np.abs(np.asarray(external.hessian - total.hessian))) > 1.0e-3
+
+
+def test_pressure_only_target_is_nonplanar_and_angle_dependent():
+    solution = _pressure_only_stellarator_solution(nphi=61)
+    total = near_axis_field_jet_target(solution)
+    external = near_axis_field_jet_target(
+        solution,
+        formal_radius=0.15,
+    )
+    plasma_field = np.asarray(total.field - external.field)
+    plasma_norm = np.linalg.norm(plasma_field, axis=1)
+    torsion_rms = np.sqrt(
+        np.sum(np.asarray(solution.torsion**2 * solution.geometry.d_l_d_phi))
+        / np.sum(np.asarray(solution.geometry.d_l_d_phi))
+    )
+
+    assert solution.inputs.I2 == 0
+    assert solution.inputs.p2 != 0
+    assert abs(float(solution.iota)) > 0.4
+    assert torsion_rms > 0.5
+    assert np.ptp(plasma_norm) / np.mean(plasma_norm) > 0.1
+    assert np.max(np.abs(np.asarray(external.field - total.field))) > 1.0e-4
     assert np.max(np.abs(np.asarray(external.hessian - total.hessian))) > 1.0e-3
 
 

--- a/tests/test_field_jet.py
+++ b/tests/test_field_jet.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import pyqsc_jax as qsc
+from essos.coils import Coils, Curves
+from essos.field_jet import (
+    FieldJetResiduals,
+    NearAxisFieldJetTarget,
+    field_jet_loss_terms,
+    loss_field_jet_coils_near_axis,
+    near_axis_field_jet_target,
+    normalized_field_jet_residuals,
+    pack_symmetric_trace_free_rank2,
+    pack_symmetric_trace_free_rank3,
+)
+from essos.fields import BiotSavart, MagneticField
+
+
+@jax.tree_util.register_pytree_node_class
+class PolynomialField(MagneticField):
+    def __init__(self, offset):
+        self.offset = jnp.asarray(offset)
+        self.linear = jnp.asarray(
+            [
+                [1.0, 0.2, -0.1],
+                [0.2, -0.4, 0.3],
+                [-0.1, 0.3, -0.6],
+            ]
+        )
+        self.quadratic = jnp.asarray(
+            [
+                [[0.3, -0.2, 0.1], [-0.2, 0.4, 0.0], [0.1, 0.0, -0.1]],
+                [[-0.2, 0.4, 0.0], [0.4, -0.1, 0.2], [0.0, 0.2, -0.3]],
+                [[0.1, 0.0, -0.1], [0.0, 0.2, -0.3], [-0.1, -0.3, -0.2]],
+            ]
+        )
+
+    def B(self, point):
+        return (
+            self.offset
+            + self.linear @ point
+            + jnp.einsum("ijk,j,k->i", self.quadratic, point, point) / 2
+        )
+
+    def tree_flatten(self):
+        return (self.offset,), {}
+
+    @classmethod
+    def tree_unflatten(cls, _, children):
+        return cls(children[0])
+
+
+def _matching_polynomial_target(field):
+    points = jnp.asarray(
+        [
+            [0.8, 0.1, -0.2],
+            [0.4, -0.3, 0.5],
+        ]
+    )
+    values = jax.vmap(field.B)(points)
+    gradients = jax.vmap(field.dB_by_dX)(points)
+    hessians = jax.vmap(field.d2B_by_dXdX)(points)
+    return NearAxisFieldJetTarget(
+        points=points,
+        field=values,
+        gradient=gradients,
+        hessian=hessians,
+        gradient_independent=pack_symmetric_trace_free_rank2(gradients),
+        hessian_independent=pack_symmetric_trace_free_rank3(hessians),
+        reference_field=jnp.asarray(2.0),
+        reference_length=jnp.asarray(3.0),
+        is_external=False,
+    )
+
+
+def _vacuum_solution(nphi=31):
+    return qsc.Qsc(
+        rc=[1.0, 0.155, 0.0102],
+        zs=[0.0, 0.154, 0.0111],
+        nfp=2,
+        etabar=0.64,
+        B2c=-0.00322,
+        nphi=nphi,
+        order="r2",
+    )
+
+
+def _finite_current_solution(nphi=31):
+    return qsc.Qsc(
+        rc=[1.0, 0.09],
+        zs=[0.0, -0.09],
+        nfp=2,
+        etabar=0.95,
+        I2=0.9,
+        p2=-600000.0,
+        B2c=-0.7,
+        nphi=nphi,
+        order="r2",
+    )
+
+
+def test_magnetic_field_hessian_matches_polynomial_coefficients():
+    field = PolynomialField(jnp.asarray([0.2, -0.1, 0.4]))
+    point = jnp.asarray([0.8, 0.1, -0.2])
+
+    np.testing.assert_allclose(
+        field.d2B_by_dXdX(point),
+        field.quadratic,
+    )
+
+
+def test_matching_target_has_zero_normalized_3_5_7_residuals():
+    field = PolynomialField(jnp.asarray([0.2, -0.1, 0.4]))
+    target = _matching_polynomial_target(field)
+    residuals = normalized_field_jet_residuals(field, target)
+
+    assert isinstance(residuals, FieldJetResiduals)
+    assert residuals.field.shape == (2, 3)
+    assert residuals.gradient.shape == (2, 5)
+    assert residuals.hessian.shape == (2, 7)
+    np.testing.assert_allclose(residuals.field, 0.0)
+    np.testing.assert_allclose(residuals.gradient, 0.0)
+    np.testing.assert_allclose(residuals.hessian, 0.0)
+    np.testing.assert_allclose(field_jet_loss_terms(field, target), 0.0)
+
+
+def test_field_jet_loss_is_smooth_normalized_and_differentiable():
+    reference = PolynomialField(jnp.asarray([0.2, -0.1, 0.4]))
+    target = _matching_polynomial_target(reference)
+
+    def loss(offset):
+        return loss_field_jet_coils_near_axis(
+            PolynomialField(offset),
+            target,
+            weights=(2.0, 3.0, 4.0),
+        )
+
+    offset = jnp.asarray([0.25, -0.07, 0.38])
+    value = loss(offset)
+    gradient = jax.grad(loss)(offset)
+    compiled = jax.jit(loss)(offset)
+    step = 1.0e-5
+    finite_difference = (
+        loss(offset.at[0].add(step)) - loss(offset.at[0].add(-step))
+    ) / (2 * step)
+
+    np.testing.assert_allclose(compiled, value)
+    np.testing.assert_allclose(gradient[0], finite_difference, rtol=2.0e-10)
+    assert value > 0
+
+
+def test_vacuum_external_target_reduces_exactly_to_total_target():
+    solution = _vacuum_solution()
+    total = near_axis_field_jet_target(solution)
+    external = near_axis_field_jet_target(
+        solution,
+        formal_radius=0.05,
+    )
+
+    assert not total.is_external
+    assert external.is_external
+    np.testing.assert_allclose(external.points, total.points)
+    np.testing.assert_allclose(external.field, total.field)
+    np.testing.assert_allclose(external.gradient, total.gradient)
+    np.testing.assert_allclose(external.hessian, total.hessian)
+    np.testing.assert_allclose(
+        external.gradient_independent,
+        total.gradient_independent,
+    )
+    np.testing.assert_allclose(
+        external.hessian_independent,
+        total.hessian_independent,
+    )
+
+
+def test_finite_current_target_uses_external_not_total_field_jet():
+    solution = _finite_current_solution(nphi=61)
+    total = near_axis_field_jet_target(solution)
+    external = near_axis_field_jet_target(
+        solution,
+        formal_radius=0.05,
+    )
+
+    assert external.is_external
+    assert external.gradient_independent.shape == (61, 5)
+    assert external.hessian_independent.shape == (61, 7)
+    assert np.max(np.abs(np.asarray(external.field - total.field))) > 1.0e-6
+    assert np.max(np.abs(np.asarray(external.gradient - total.gradient))) > 1.0e-3
+    assert np.max(np.abs(np.asarray(external.hessian - total.hessian))) > 1.0e-3
+
+
+def test_legacy_near_axis_adapter_is_accepted():
+    legacy = qsc.near_axis(
+        rc=[1.0, 0.155, 0.0102],
+        zs=[0.0, 0.154, 0.0111],
+        nfp=2,
+        etabar=0.64,
+        B2c=-0.00322,
+        nphi=31,
+        order="r2",
+    )
+    target = near_axis_field_jet_target(legacy)
+
+    np.testing.assert_allclose(
+        target.points, legacy.solution.geometry.position_cartesian
+    )
+    np.testing.assert_allclose(target.field, legacy.solution.B_axis)
+
+
+def test_actual_biot_savart_field_jet_has_coil_current_gradient():
+    points = jnp.asarray([[0.0, 0.0, 0.2], [0.1, 0.0, -0.2]])
+    zero_gradient = jnp.zeros((2, 3, 3))
+    zero_hessian = jnp.zeros((2, 3, 3, 3))
+    target = NearAxisFieldJetTarget(
+        points=points,
+        field=jnp.zeros((2, 3)),
+        gradient=zero_gradient,
+        hessian=zero_hessian,
+        gradient_independent=pack_symmetric_trace_free_rank2(zero_gradient),
+        hessian_independent=pack_symmetric_trace_free_rank3(zero_hessian),
+        reference_field=jnp.asarray(1.0),
+        reference_length=jnp.asarray(1.0),
+        is_external=False,
+    )
+
+    def loss(parameters):
+        dofs = jnp.zeros((1, 3, 3))
+        dofs = dofs.at[0, 0, 2].set(parameters[0])
+        dofs = dofs.at[0, 1, 1].set(1.0)
+        curves = Curves(
+            dofs,
+            n_segments=24,
+            nfp=1,
+            stellsym=False,
+        )
+        coils = Coils(
+            curves,
+            jnp.atleast_1d(parameters[1]),
+            currents_scale=1.0e6,
+        )
+        return loss_field_jet_coils_near_axis(BiotSavart(coils), target)
+
+    parameters = jnp.asarray([1.0, 1.0e6])
+    value, derivative = jax.value_and_grad(loss)(parameters)
+    steps = (1.0e-5, 1.0)
+    finite_difference = []
+    for index, step in enumerate(steps):
+        direction = jnp.zeros(2).at[index].set(step)
+        finite_difference.append(
+            (loss(parameters + direction) - loss(parameters - direction)) / (2 * step)
+        )
+
+    assert np.isfinite(value)
+    np.testing.assert_allclose(
+        derivative,
+        finite_difference,
+        rtol=2.0e-7,
+    )
+
+
+def test_finite_current_objective_has_axis_and_near_axis_gradients():
+    coil_field = PolynomialField(jnp.asarray([0.2, -0.1, 0.4]))
+
+    def loss(parameters):
+        solution = qsc.Qsc(
+            rc=jnp.stack((jnp.asarray(1.0), parameters[0])),
+            zs=[0.0, -0.09],
+            nfp=2,
+            etabar=parameters[1],
+            I2=0.9,
+            p2=-600000.0,
+            B2c=-0.7,
+            nphi=15,
+            order="r2",
+        )
+        target = near_axis_field_jet_target(
+            solution,
+            formal_radius=0.05,
+            angular_resolution=32,
+        )
+        return loss_field_jet_coils_near_axis(coil_field, target)
+
+    parameters = jnp.asarray([0.09, 0.95])
+    value, derivative = jax.value_and_grad(loss)(parameters)
+    finite_difference = []
+    for index in range(2):
+        direction = jnp.zeros(2).at[index].set(1.0e-5)
+        finite_difference.append(
+            (loss(parameters + direction) - loss(parameters - direction)) / (2.0e-5)
+        )
+
+    assert np.isfinite(value)
+    np.testing.assert_allclose(
+        derivative,
+        finite_difference,
+        rtol=1.0e-6,
+        atol=1.0e-7,
+    )
+
+
+def test_target_and_weight_guards():
+    first_order = qsc.Qsc(
+        rc=[1.0, 0.045],
+        zs=[0.0, -0.045],
+        nfp=3,
+        etabar=-0.9,
+        nphi=15,
+    )
+    with pytest.raises(ValueError, match="r2 or r3"):
+        near_axis_field_jet_target(first_order)
+    with pytest.raises(ValueError, match="positive"):
+        near_axis_field_jet_target(_vacuum_solution(), reference_field=0.0)
+    with pytest.raises(ValueError, match=r"shape \(3,\)"):
+        loss_field_jet_coils_near_axis(
+            PolynomialField(jnp.zeros(3)),
+            _matching_polynomial_target(PolynomialField(jnp.zeros(3))),
+            weights=(1.0, 2.0),
+        )

--- a/tests/test_field_jet_examples.py
+++ b/tests/test_field_jet_examples.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+PYQSC_SOURCE = REPOSITORY.parent / "pyQSC_JAX" / "src"
+
+
+@pytest.mark.parametrize(
+    "script, expected_text",
+    [
+        (
+            "optimize_coils_for_external_nearaxis.py",
+            "final normalized objective:",
+        ),
+        (
+            "optimize_coils_and_external_nearaxis.py",
+            "final near-axis variables",
+        ),
+    ],
+)
+def test_external_field_jet_examples_run(tmp_path, script, expected_text):
+    environment = os.environ.copy()
+    environment["JAX_ENABLE_X64"] = "true"
+    environment["MPLBACKEND"] = "Agg"
+    environment["PYTHONPATH"] = os.pathsep.join(
+        (
+            str(PYQSC_SOURCE),
+            str(REPOSITORY),
+            environment.get("PYTHONPATH", ""),
+        )
+    )
+    script_path = REPOSITORY / "examples" / "coil_optimization" / script
+
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert expected_text in result.stdout

--- a/tests/test_field_jet_examples.py
+++ b/tests/test_field_jet_examples.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
-
 
 REPOSITORY = Path(__file__).resolve().parents[1]
 PYQSC_SOURCE = REPOSITORY.parent / "pyQSC_JAX" / "src"
@@ -44,7 +43,7 @@ def test_external_field_jet_examples_run(tmp_path, script, expected_text):
         env=environment,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=300,
         check=False,
     )
 


### PR DESCRIPTION
## Summary

- add a generic JAX magnetic-field Hessian interface;
- consume pyQSC_JAX total-vacuum or surface-free external field jets;
- use smooth, dimensionally normalized 3+5+7 least-squares residual blocks;
- verify exact vacuum reduction and finite-beta external-target subtraction;
- differentiate through real coil shapes/currents and pyQSC_JAX
  axis/physics variables;
- add executable finite-beta stage-two and single-stage optimization
  examples.

## Pressure-only stellarator examples

Both demonstrations now use public database-backed
`plasma_stellarator` (Wisconsin database ID 52521):

- finite `p2` and exactly `I2 = 0`;
- nonplanar axis with nonzero torsion;
- `|iota| > 2.8`;
- formal radius `0.15 m`;
- normalized field, STF-gradient, and STF-Hessian residual blocks.

The single-stage design vector is `(rc1, zs1, etabar, B2c)`; toroidal current
is fixed at zero and cannot drift toward a tokamak-like solution. Saved
metadata include the complete Fourier axis and database provenance.

## Validation

- **13 focused tests pass**, including both optimization scripts in clean
  subprocesses.
- The pressure-only regression checks finite pressure, exactly zero current,
  `|iota| > 0.4`, RMS torsion above `0.5 1/m`, more than 10% angular
  variation in the plasma-field norm, and nonzero field/Hessian subtraction.
- Stage two: normalized objective `6.7102e7 -> 4.4677e3`; field, gradient,
  and Hessian block sums independently decrease
  `4.4786 -> 0.7913`, `2.0187e4 -> 72.3078`, and
  `2.6833e8 -> 1.7578e4`.
- Single stage: objective `6.7102e7 -> 3.0052e4`; final blocks are
  `0.6382`, `137.638`, and `1.1966e5`; weighted B20 residual
  `0.2930 -> 0.2514`; final `|iota| = 2.843`, `I2 = 0`, and RMS torsion
  `0.856 1/m`.
- Coil-shape/current and near-axis gradients agree with finite differences;
  vacuum reduction is exact.

These deliberately short runs are execution and coupled-gradient
demonstrations, not claims of device-quality global optima.

## Dependency and inherited state

This draft is paired with
[uwplasma/pyQSC_JAX#2](https://github.com/uwplasma/pyQSC_JAX/pull/2);
the final boundary/VMEX hardening source commit is `060aef3`. Dependency
direction remains `ESSOS -> pyQSC_JAX`.

The ESSOS base branch retains unrelated collection, formatting, and
documentation failures already present before this patch. They remain
disclosed rather than being mixed into the field-jet integration. No
generated optimization output is committed.

This PR should remain draft until the paired pyQSC_JAX API lands.

