### PR TITLE
Fill VMEC event output tails

### DIFF
--- a/essos/dynamics.py
+++ b/essos/dynamics.py
@@ -674,7 +674,9 @@ def FieldLine(t,
 
 
 @jit
-def _fill_terminated_trajectories(trajectories, axis_threshold=None):
+def _fill_terminated_trajectories(
+    trajectories, axis_threshold=None, boundary_threshold=None
+):
     """Replace post-event or below-axis saves with the last valid state."""
 
     def fill_trajectory(trajectory):
@@ -682,6 +684,8 @@ def _fill_terminated_trajectories(trajectories, axis_threshold=None):
             is_valid = jnp.isfinite(current).all()
             if axis_threshold is not None:
                 is_valid = is_valid & (current[0] > axis_threshold)
+            if boundary_threshold is not None:
+                is_valid = is_valid & (current[0] < boundary_threshold)
             state = jnp.where(is_valid, current, previous)
             return state, state
 
@@ -933,10 +937,14 @@ class Tracing():
         if self._has_vmec_axis_event:
             self.axis_hits, self.boundary_hits = self.event_mask
             filled = _fill_terminated_trajectories(
-                trajectories, self.axis_threshold
+                trajectories,
+                self.axis_threshold,
+                self.boundary_threshold,
             )
             self._trajectories = jnp.where(
-                self.axis_hits[:, None, None], filled, trajectories
+                (self.axis_hits | self.boundary_hits)[:, None, None],
+                filled,
+                trajectories,
             )
             self.custom_hits = jnp.zeros(len(trajectories), dtype=bool)
         elif self._has_custom_event:


### PR DESCRIPTION
Fills post-event output for both magnetic-axis and boundary terminations with the last finite in-domain sample.

Termination time and state remain available from #53. Loss accounting remains event-based, so filling the sampled output does not change the loss fraction.

The QP trace kept 90 losses and 8 axis terminations. All 200 sampled trajectories were finite after this change.

Depends on #55. No test files changed.
