### PR TITLE
Differentiable alpha loss fraction and in-memory Vmec construction

### DIFF
--- a/essos/dynamics.py
+++ b/essos/dynamics.py
@@ -1310,6 +1310,23 @@ class Tracing():
         total_particles_lost = loss_fractions[-1] * len(self.trajectories)
         return loss_fractions, total_particles_lost, lost_times
 
+    def soft_loss_fraction(self, r_max=0.99, width=0.02):
+        """Differentiable surrogate for the final value of `loss_fraction`.
+
+        Each particle contributes ``sigmoid((r_soft - r_max) / width)``, where ``r_soft``
+        is the softmax-weighted mean of its radial coordinate over time, a soft maximum
+        that spreads the gradient over every sample near the radial excursion peak;
+        `jnp.max` would route the gradient through the single peak sample and leave the
+        objective almost flat. It is preferred over a plain ``width * logsumexp(r/width)``,
+        which carries a ``width * log(n_times)`` offset set by the save grid rather than
+        by the orbit. The surrogate converges to `loss_fraction` as `width` goes to zero.
+        Saves past a terminating event count as reaching the boundary.
+        """
+        trajectories_r = self.trajectories[:, :, 0]
+        trajectories_r = jnp.where(jnp.isfinite(trajectories_r), trajectories_r, 1.0)
+        r_soft = jnp.sum(trajectories_r * jax.nn.softmax(trajectories_r / width, axis=1), axis=1)
+        return jnp.mean(jax.nn.sigmoid((r_soft - r_max) / width))
+
 
 
     @partial(jit, static_argnums=(0,1))

--- a/essos/fields.py
+++ b/essos/fields.py
@@ -213,27 +213,58 @@ class BiotSavart_from_gamma(MagneticField):
     def to_xyz(self, points):
         return points
 
+VMEC_WOUT_ARRAYS = ('bmnc', 'xm', 'xn', 'rmnc', 'zmns', 'bsubsmns', 'bsubumnc', 'bsubvmnc',
+                    'bsupumnc', 'bsupvmnc', 'gmnc', 'xm_nyq', 'xn_nyq', 'Aminor_p')
+
 class Vmec():
     def __init__(self, wout_filename, ntheta=50, nphi=50, close=True, range_torus='full torus'):
         self.wout_filename = wout_filename
         from netCDF4 import Dataset
         self.nc = Dataset(self.wout_filename)
-        self.nfp = int(self.nc.variables["nfp"][0])
-        self.bmnc = jnp.array(self.nc.variables["bmnc"][:])
-        self.xm = jnp.array(self.nc.variables["xm"][:])
-        self.xn = jnp.array(self.nc.variables["xn"][:])
-        self.rmnc = jnp.array(self.nc.variables["rmnc"][:])
-        self.zmns = jnp.array(self.nc.variables["zmns"][:])
-        self.bsubsmns = jnp.array(self.nc.variables["bsubsmns"][:])
-        self.bsubumnc = jnp.array(self.nc.variables["bsubumnc"][:])
-        self.bsubvmnc = jnp.array(self.nc.variables["bsubvmnc"][:])
-        self.bsupumnc = jnp.array(self.nc.variables["bsupumnc"][:])
-        self.bsupvmnc = jnp.array(self.nc.variables["bsupvmnc"][:])
-        self.gmnc = jnp.array(self.nc.variables["gmnc"][:])
-        self.xm_nyq = jnp.array(self.nc.variables["xm_nyq"][:])
-        self.xn_nyq = jnp.array(self.nc.variables["xn_nyq"][:])
+        self._set_state(nfp=int(self.nc.variables["nfp"][0]), ns=int(self.nc.variables["ns"][0]),
+                        ntheta=ntheta, nphi=nphi, close=close, range_torus=range_torus,
+                        **{name: jnp.array(self.nc.variables[name][:]) for name in VMEC_WOUT_ARRAYS})
+
+    @classmethod
+    def from_arrays(cls, nfp, ns, bmnc, xm, xn, rmnc, zmns, bsubsmns, bsubumnc, bsubvmnc,
+                    bsupumnc, bsupvmnc, gmnc, xm_nyq, xn_nyq, Aminor_p,
+                    ntheta=50, nphi=50, close=True, range_torus='full torus'):
+        """Build a Vmec field from wout quantities held in memory.
+
+        The arguments carry the wout variable names and are stored as given, so JAX
+        tracers reach B, AbsB and the traced trajectories and the field stays
+        differentiable with respect to its spectral coefficients. ``nfp``, ``ns`` and
+        the mode numbers set array shapes and must be concrete.
+        """
+        self = cls.__new__(cls)
+        self.wout_filename = None
+        self.nc = None
+        self._set_state(nfp=nfp, ns=ns, bmnc=bmnc, xm=xm, xn=xn, rmnc=rmnc, zmns=zmns,
+                        bsubsmns=bsubsmns, bsubumnc=bsubumnc, bsubvmnc=bsubvmnc,
+                        bsupumnc=bsupumnc, bsupvmnc=bsupvmnc, gmnc=gmnc, xm_nyq=xm_nyq,
+                        xn_nyq=xn_nyq, Aminor_p=Aminor_p, ntheta=ntheta, nphi=nphi,
+                        close=close, range_torus=range_torus)
+        return self
+
+    def _set_state(self, nfp, ns, bmnc, xm, xn, rmnc, zmns, bsubsmns, bsubumnc, bsubvmnc,
+                   bsupumnc, bsupvmnc, gmnc, xm_nyq, xn_nyq, Aminor_p,
+                   ntheta, nphi, close, range_torus):
+        self.nfp = nfp
+        self.bmnc = bmnc
+        self.xm = xm
+        self.xn = xn
+        self.rmnc = rmnc
+        self.zmns = zmns
+        self.bsubsmns = bsubsmns
+        self.bsubumnc = bsubumnc
+        self.bsubvmnc = bsubvmnc
+        self.bsupumnc = bsupumnc
+        self.bsupvmnc = bsupvmnc
+        self.gmnc = gmnc
+        self.xm_nyq = xm_nyq
+        self.xn_nyq = xn_nyq
         self.len_xm_nyq = len(self.xm_nyq)
-        self.ns = self.nc.variables["ns"][0]
+        self.ns = ns
         self.s_full_grid = jnp.linspace(0, 1, self.ns)
         self.ds = self.s_full_grid[1] - self.s_full_grid[0]
         self.s_half_grid = self.s_full_grid[1:] - 0.5 * self.ds
@@ -243,7 +274,7 @@ class Vmec():
         self.ntor = int(jnp.max(jnp.abs(self.xn)) / self.nfp)
         self.range_torus = range_torus
         self._surface = SurfaceRZFourier.from_vmec(self, ntheta=ntheta, nphi=nphi, close=close, range_torus=range_torus)
-        self.Aminor_p = jnp.array(self.nc.variables["Aminor_p"][:])
+        self.Aminor_p = Aminor_p
         #self._classifier=SurfaceClassifier(self._surface,p=1,h=0.05)
         
     @property

--- a/essos/objective_functions.py
+++ b/essos/objective_functions.py
@@ -163,6 +163,16 @@ def loss_particle_iota(field, particles, timestep=1.e-8, maxtime=1e-5, num_steps
     B_phi=jnp.multiply(B_particle[:,:,0],dphi_dx)+jnp.multiply(B_particle[:,:,1],dphi_dy)
     return jnp.sum(jnp.maximum(target_iota-B_theta/B_phi,0.0))
 
+def loss_soft_lost_fraction(field, particles, timestep=1.e-8, maxtime=1e-5, num_steps=300, trace_tolerance=1e-5, model='GuidingCenterAdaptative',boundary=None,r_max=0.99,width=0.02):
+    """Smooth surrogate of the fraction of particles lost past ``r_max``.
+
+    Differentiable with respect to the field, so alpha confinement can drive
+    gradient-based optimization. Report `Tracing.loss_fraction` for the exact value.
+    """
+    tracing = Tracing(field=field, model=model, particles=particles, maxtime=maxtime,
+                      timestep=timestep,times_to_trace=num_steps, atol=trace_tolerance,rtol=trace_tolerance,boundary=boundary)
+    return tracing.soft_loss_fraction(r_max=r_max, width=width)
+
 
 
 

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -1,4 +1,6 @@
+import os
 import pytest
+import jax
 import jax.numpy as jnp
 from essos.constants import ALPHA_PARTICLE_MASS, ALPHA_PARTICLE_CHARGE, FUSION_ALPHA_PARTICLE_ENERGY,ELECTRON_MASS,PROTON_MASS
 from essos.dynamics import (
@@ -12,7 +14,10 @@ from essos.dynamics import (
     _VMEC_GUIDING_CENTER_MODELS,
 )
 from essos.background_species import BackgroundSpecies
-from essos.fields import Vmec
+from essos.fields import Vmec, VMEC_WOUT_ARRAYS
+
+WOUT_FILE = os.path.join(os.path.dirname(__file__), "..", "examples", "input_files",
+                         "wout_LandremanPaul2021_QA_reactorScale_lowres.nc")
 
 def test_particles_initialization_all_params():
     nparticles = 100
@@ -217,6 +222,58 @@ def test_vmec_axis_event_terminates_deterministic_steppers(model):
     assert tracing.total_particles_lost == 0
     assert jnp.isfinite(tracing.trajectories).all()
     assert jnp.all(tracing.trajectories[:, :, 0] > tracing.axis_threshold)
+
+
+def radial_tracing(peaks, times=jnp.linspace(0.0, 1.0, 40)):
+    """Tracing holding prescribed radial excursions, bypassing the ODE solve."""
+    trajectories_r = 0.5 + (peaks[:, None] - 0.5) * jnp.sin(jnp.pi * times)[None, :]
+    tracing = Tracing.__new__(Tracing)
+    tracing.trajectories = jnp.stack([trajectories_r, jnp.zeros_like(trajectories_r), jnp.zeros_like(trajectories_r)], axis=-1)
+    tracing.times = times
+    return tracing
+
+def test_soft_loss_fraction_converges_to_loss_fraction():
+    tracing = radial_tracing(jnp.array([0.70, 0.93, 0.86, 0.99]))
+    exact = tracing.loss_fraction(r_max=0.9)[0][-1]
+    assert exact == 0.5
+
+    errors = [abs(float(tracing.soft_loss_fraction(r_max=0.9, width=width) - exact)) for width in (0.02, 0.01, 0.005, 0.002)]
+    assert errors == sorted(errors, reverse=True)
+    assert errors[-1] < 1e-3
+
+def test_soft_loss_fraction_gradient_is_nonzero_where_loss_fraction_is_flat():
+    peaks = jnp.array([0.70, 0.93, 0.86, 0.99])
+    exact_gradient = jax.grad(lambda p: radial_tracing(p).loss_fraction(r_max=0.9)[0][-1])(peaks)
+    soft_gradient = jax.grad(lambda p: radial_tracing(p).soft_loss_fraction(r_max=0.9, width=0.01))(peaks)
+
+    assert jnp.all(exact_gradient == 0.0)
+    assert jnp.all(soft_gradient[1:] > 0.0)
+
+def vmec_alpha_tracing(field, nparticles=4, maxtime=4e-6, times_to_trace=10):
+    theta = jnp.linspace(0, 2*jnp.pi, nparticles)
+    phi = jnp.linspace(0, 2*jnp.pi/field.nfp, nparticles)
+    particles = Particles(initial_xyz=jnp.array([0.85*jnp.ones(nparticles), theta, phi]).T, mass=ALPHA_PARTICLE_MASS,
+                          charge=ALPHA_PARTICLE_CHARGE, energy=FUSION_ALPHA_PARTICLE_ENERGY, field=field)
+    return Tracing(field=field, model='GuidingCenterAdaptative', particles=particles, maxtime=maxtime,
+                   timestep=1e-8, times_to_trace=times_to_trace, atol=1e-5, rtol=1e-5)
+
+def test_vmec_from_arrays_traces_identically():
+    vmec = Vmec(WOUT_FILE)
+    rebuilt = Vmec.from_arrays(nfp=vmec.nfp, ns=vmec.ns, **{name: getattr(vmec, name) for name in VMEC_WOUT_ARRAYS})
+
+    assert jnp.array_equal(vmec_alpha_tracing(rebuilt).trajectories, vmec_alpha_tracing(vmec).trajectories)
+
+def test_soft_loss_fraction_differentiates_vmec_coefficients():
+    vmec = Vmec(WOUT_FILE)
+    arrays = {name: getattr(vmec, name) for name in VMEC_WOUT_ARRAYS}
+    scaled = ('bmnc', 'bsubsmns', 'bsubumnc', 'bsubvmnc', 'bsupumnc', 'bsupvmnc')
+
+    def soft_loss_of_field_scale(scale):
+        field = Vmec.from_arrays(nfp=vmec.nfp, ns=vmec.ns,
+                                 **{**arrays, **{name: arrays[name]*scale for name in scaled}})
+        return vmec_alpha_tracing(field).soft_loss_fraction(r_max=0.88, width=0.01)
+
+    assert jax.grad(soft_loss_of_field_scale)(1.0) != 0.0
 
 
 def test_tracing_initialization(field, particles,electric_field):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,12 @@
+import os
 import pytest
-from essos.fields import BiotSavart
+import jax
+from essos.fields import BiotSavart, Vmec, VMEC_WOUT_ARRAYS
 import jax.numpy as jnp
-from jax import random
+from jax import random, vmap
+
+WOUT_FILE = os.path.join(os.path.dirname(__file__), "..", "examples", "input_files",
+                         "wout_LandremanPaul2021_QA_reactorScale_lowres.nc")
 
 class MockCoils:
     def __init__(self):
@@ -60,6 +65,27 @@ def test_biot_savart_initialization():
 #     points = jnp.array([0.5, 0.5, 0.5])
 #     dAbsB_by_dX = biot_savart.dAbsB_by_dX(points)
 #     assert jnp.allclose(dAbsB_by_dX, jnp.array([7.16688661e-05, 3.82872752e-05, 1.01490560e-04]))
+
+def test_vmec_from_arrays_matches_wout_file():
+    vmec = Vmec(WOUT_FILE)
+    rebuilt = Vmec.from_arrays(nfp=vmec.nfp, ns=vmec.ns,
+                               **{name: getattr(vmec, name) for name in VMEC_WOUT_ARRAYS})
+    points = jnp.array([[0.3, 0.4, 0.5], [0.7, 1.2, 0.2], [0.9, 3.0, 1.1]])
+
+    assert (rebuilt.nfp, rebuilt.ns, rebuilt.mpol, rebuilt.ntor) == (vmec.nfp, vmec.ns, vmec.mpol, vmec.ntor)
+    assert jnp.array_equal(vmap(rebuilt.B)(points), vmap(vmec.B)(points))
+    assert jnp.array_equal(vmap(rebuilt.AbsB)(points), vmap(vmec.AbsB)(points))
+    assert jnp.array_equal(rebuilt.surface.gamma, vmec.surface.gamma)
+
+def test_vmec_from_arrays_is_differentiable_in_the_coefficients():
+    vmec = Vmec(WOUT_FILE)
+    arrays = {name: getattr(vmec, name) for name in VMEC_WOUT_ARRAYS}
+    point = jnp.array([0.7, 1.2, 0.2])
+
+    def AbsB_of_scale(scale):
+        return Vmec.from_arrays(nfp=vmec.nfp, ns=vmec.ns, **{**arrays, 'bmnc': arrays['bmnc']*scale}).AbsB(point)
+
+    assert jnp.isclose(jax.grad(AbsB_of_scale)(1.0), vmec.AbsB(point))
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_objective_functions.py
+++ b/tests/test_objective_functions.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 
 import essos.objective_functions as objf
+from essos.dynamics import Tracing
 
 
 class DummyCoils:
@@ -85,6 +86,9 @@ class DummyTracing:
         self.loss_fractions = jnp.array([0.1, 0.2, 1.0])
         self.times_to_trace = 4
         self.maxtime = 1e-5
+
+    def soft_loss_fraction(self, r_max=0.99, width=0.02):
+        return Tracing.soft_loss_fraction(self, r_max=r_max, width=width)
 
 
 @jax.tree_util.register_pytree_node_class
@@ -216,6 +220,8 @@ class TestObjectiveFunctions(unittest.TestCase):
         self.assertTrue(jnp.isfinite(objf.loss_particle_rcross_final(self.field, self.particles)))
         self.assertTrue(jnp.isfinite(objf.loss_particle_Br(self.field, self.particles)))
         self.assertTrue(jnp.isfinite(objf.loss_particle_iota(self.field, self.particles)))
+        soft_lost_fraction = objf.loss_soft_lost_fraction(self.field, self.particles, r_max=1.2, width=0.05)
+        self.assertTrue(0.0 <= soft_lost_fraction <= 1.0)
 
     @patch("essos.objective_functions.BdotN_over_B", return_value=jnp.ones((2, 3), dtype=jnp.float64))
     def test_surface_losses(self, bdotn):


### PR DESCRIPTION
Makes the alpha-particle loss fraction usable as a differentiable objective driven by a VMEC equilibrium whose spectral coefficients are live JAX arrays. This unblocks `vmex --trace wout_XXX.nc` and boundary optimization against alpha losses in [vmex](https://github.com/uwplasma/vmex), which holds the wout arrays in memory as tracers.

## Gap 1: `Vmec` could only be built from a netCDF file

`Vmec.__init__` opened the wout with `Dataset(...)`. A caller already holding `bmnc`, `rmnc`, `bsup*`, ... as traced JAX arrays had to write a file first, which severs the gradient path.

### API

```python
Vmec.from_arrays(nfp, ns, bmnc, xm, xn, rmnc, zmns, bsubsmns, bsubumnc, bsubvmnc,
                 bsupumnc, bsupvmnc, gmnc, xm_nyq, xn_nyq, Aminor_p,
                 ntheta=50, nphi=50, close=True, range_torus='full torus')
```

Arguments carry the wout variable names and are stored as passed — no `np.asarray` round trip — so tracers reach `B`, `AbsB` and the traced trajectories. `nfp`, `ns` and the mode numbers set array shapes and must be concrete. `VMEC_WOUT_ARRAYS` names the array arguments for callers that want to forward them in bulk. `Vmec(wout_filename)` reads the same values from the file and hands them to the same code path, so the file route is unchanged.

Verified against `examples/input_files/wout_LandremanPaul2021_QA_reactorScale_lowres.nc`, comparing a file-built `Vmec` with one rebuilt from its own arrays:

| quantity | result |
| --- | --- |
| `B` at 3 points | bit-identical |
| `AbsB` at 3 points | bit-identical |
| `surface.gamma` | bit-identical |
| `(nfp, ns, mpol, ntor)` | `(2, 50, 4, 5)` both |
| traced trajectories, 4 alphas, `tmax=4e-6` | bit-identical |

## Gap 2: the loss fraction had an identically zero gradient

`Tracing.loss_fraction` builds `trajectories_r >= r_max`, then `argmax`, `bincount`, `cumsum`. All piecewise-constant in the trajectories, so `jax.grad` returns exactly zero and the objective is only reachable by gradient-free optimizers.

Measured with 8 alphas launched at `s=0.85`, `tmax=5e-6`, 30 saves, `atol=rtol=1e-5`, differentiating with respect to a scale on every B-related coefficient (`bmnc`, `bsub*`, `bsup*`) passed through `Vmec.from_arrays`, at `r_max=0.88`:

| | value | `jax.grad` |
| --- | --- | --- |
| `loss_fraction` (exact) | 0.2500 | **0.0** |
| `soft_loss_fraction`, `width=0.05` | 0.371216 | -5.671810e-02 |
| `soft_loss_fraction`, `width=0.02` | 0.306422 | -1.341416e-01 |
| `soft_loss_fraction`, `width=0.005` | 0.256971 | -8.715592e-02 |

### The surrogate

```python
Tracing.soft_loss_fraction(r_max=0.99, width=0.02)
```

For each particle `i` with radial coordinate `r_i(t)`:

```
r_soft_i = sum_t r_i(t) * softmax_t(r_i(t) / width)
surrogate = mean_i sigmoid((r_soft_i - r_max) / width)
```

`r_soft` is the softmax-weighted mean over time: a soft maximum that spreads the gradient over every sample near the radial excursion peak. `jnp.max` is subdifferentiable but routes the gradient through the single peak sample, which is far too sparse to optimize against. It is also preferred over a plain `width * logsumexp(r/width)`, which carries a `width * log(n_times)` offset fixed by how densely the trajectories are saved rather than by the orbit; the softmax-weighted mean is exact for a flat profile and its bias on a peaked one is `O(width)` with no `n_times` dependence. Non-finite saves past a terminating event are treated as having reached the boundary.

The single `width` keyword sets both the soft-maximum temperature and the crossing sharpness, both in units of `s`.

### Convergence in value

Same trace as above, `r_max=0.88`, exact `loss_fraction = 0.2500`:

| width | surrogate | exact | \|diff\| |
| --- | --- | --- | --- |
| 0.1 | 0.421020 | 0.2500 | 0.171020 |
| 0.05 | 0.371216 | 0.2500 | 0.121216 |
| 0.02 | 0.306422 | 0.2500 | 0.056422 |
| 0.01 | 0.267036 | 0.2500 | 0.017036 |
| 0.005 | 0.256971 | 0.2500 | 0.006971 |
| 0.002 | 0.251475 | 0.2500 | 0.001475 |
| 0.001 | 0.250049 | 0.2500 | 0.000049 |

On four prescribed sinusoidal radial excursions peaking at `s = 0.70, 0.93, 0.86, 0.99` with `r_max=0.9`, exact loss fraction 0.5, the per-particle gradient at `width=0.01` is `[3.1e-08, 1.757, 0.271, 5.1e-03]` against `[0, 0, 0, 0]` for the exact one. The near-miss particle at 0.86 carries real weight, which is what lets an optimizer see a boundary before losses appear.

### Objective

```python
loss_soft_lost_fraction(field, particles, timestep=1.e-8, maxtime=1e-5, num_steps=300,
                        trace_tolerance=1e-5, model='GuidingCenterAdaptative',
                        boundary=None, r_max=0.99, width=0.02)
```

Placed with the other particle confinement losses in `essos/objective_functions.py`.

## The exact diagnostic is unchanged

`Tracing.loss_fraction` is untouched. It remains the physically correct reported quantity and still returns `(loss_fractions, total_particles_lost, lost_times)` exactly as before. `soft_loss_fraction` sits alongside it and is only for driving gradients.

## Tests

Added to the existing files, no new test module:

- `tests/test_fields.py` — `from_arrays` reproduces the file-built field; `jax.grad` flows through `from_arrays` into `AbsB`.
- `tests/test_dynamics.py` — surrogate converges to the exact value as `width` shrinks; exact gradient is zero where the surrogate's is not; `from_arrays` traces identically to the file route; `soft_loss_fraction` differentiates VMEC coefficients end to end.
- `tests/test_objective_functions.py` — `loss_soft_lost_fraction` in the mocked particle-loss test.

```
pytest tests/test_fields.py tests/test_dynamics.py tests/test_objective_functions.py -q
38 passed in 43.30s

pytest tests/ -q
85 passed, 1 xfailed in 49.59s
```
