### PR TITLE
Add a VMEX interoperability example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
     - [From Source](#from-source)
 - [Usage](#usage)
   - [VMEC magnetic-axis handling](#vmec-magnetic-axis-handling)
+  - [VMEC equilibria with VMEX](#vmec-equilibria-with-vmex)
 - [Testing](#testing)
 - [Project Roadmap](#project-roadmap)
 - [Contributing](#contributing)
@@ -170,6 +171,23 @@ This is a numerical safeguard, not a physical continuation through the axis.
 A trajectory that must continue across the axis requires a regular coordinate
 chart (for example, pseudo-Cartesian flux coordinates) or a Cartesian/full-orbit
 handoff.
+
+### VMEC equilibria with VMEX
+
+[VMEX](https://github.com/uwplasma/VMEX) (`pip install vmex`) is a JAX
+implementation of VMEC, and the two packages meet without either importing the
+other. Coils leave ESSOS as a Biot-Savart field tabulated onto a cylindrical
+grid, which is what VMEX's free-boundary solver consumes; the equilibrium comes
+back as a wout file, which is what `essos.fields.Vmec` reads.
+
+```sh
+python examples/simple_examples/equilibrium_from_coils_vmex.py
+```
+
+That example holds a QA plasma with the bundled `Coils`, solves the free
+boundary in VMEX, reads the result back as a `Vmec` field and traces field
+lines through it. The rotational transform it measures agrees with the one VMEX
+computed from force balance to one part in 1e4.
 
 ## Testing
 To run the tests, use `pytest`:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -25,3 +25,16 @@ To run the one of the examples, use the following command:
     python examples/trace_fieldlines_coils.py
 
 More examples are in the `examples` folder.
+
+VMEC equilibria with VMEX
+-------------------------
+
+`VMEX <https://github.com/uwplasma/VMEX>`_ (``pip install vmex``) solves the
+VMEC equilibrium ESSOS traces through, and neither package imports the other:
+coils leave ESSOS as a Biot-Savart field tabulated onto a cylindrical grid,
+which VMEX's free-boundary solver consumes, and the equilibrium comes back as
+a wout file, which ``essos.fields.Vmec`` reads.
+
+.. code-block:: console
+
+    python examples/simple_examples/equilibrium_from_coils_vmex.py

--- a/examples/simple_examples/equilibrium_from_coils_vmex.py
+++ b/examples/simple_examples/equilibrium_from_coils_vmex.py
@@ -1,0 +1,102 @@
+# A VMEC equilibrium held by ESSOS coils, solved by vmex (pip install vmex).
+# Coils go out as a tabulated Biot-Savart grid, the equilibrium comes back as
+# a wout that essos.fields.Vmec reads: neither package imports the other.
+import os
+number_of_processors_to_use = 1
+os.environ["XLA_FLAGS"] = f'--xla_force_host_platform_device_count={number_of_processors_to_use}'
+from time import time
+import numpy as np
+import jax.numpy as jnp
+from jax import jit, vmap
+import matplotlib.pyplot as plt
+import vmex as vj
+from dataclasses import replace
+from essos.coils import Coils
+from essos.fields import BiotSavart, Vmec
+from essos.dynamics import Tracing
+
+# Input parameters
+ns = 16                      # radial surfaces; raise for a production run
+phiedge = -0.025             # toroidal flux these coil currents hold [Wb]
+mgrid_bounds = dict(rmin=0.45, rmax=1.55, zmin=-0.6, zmax=0.6)
+mgrid_shape = dict(ir=96, jz=96, kp=32)   # NZETA below must divide kp
+s_fieldline = 0.5
+nfieldlines = 4
+tmax_fieldline = 800.        # about 120 toroidal turns
+num_steps = 3000
+CI = os.environ.get("VMEX_EXAMPLES_CI") == "1"   # the switch vmex's examples read
+
+input_dir = os.path.join(os.path.dirname(__file__), '..', 'input_files')
+output_dir = os.path.join(os.path.dirname(__file__), '..', 'output')
+os.makedirs(output_dir, exist_ok=True)
+
+# Load coils and build the field
+coils = Coils.from_json(os.path.join(input_dir, 'ESSOS_biot_savart_LandremanPaulQA.json'))
+biot_savart = jit(vmap(BiotSavart(coils).B))
+
+
+# vmex tabulates a Cartesian field onto a cylindrical grid; its adapter calls
+# B once per point, so vmap it and chunk to bound the coil-segment intermediate
+def coil_field(points):
+    return np.concatenate([np.asarray(biot_savart(chunk))
+                           for chunk in np.array_split(np.asarray(points), 64)])
+
+
+time0 = time()
+external_field = vj.MgridField.from_cartesian_field(
+    coil_field, nfp=int(coils.nfp), **mgrid_bounds, **mgrid_shape)
+print(f"Tabulating {np.asarray(coils.currents).size} filaments took {time()-time0:.2f} seconds")
+
+# The QA deck ESSOS ships is reactor scale; scale_input maps it onto the unit
+# size these coils were optimized for.  It only seeds the guess: with LFREEB
+# the last closed surface is solved for, not prescribed.
+seed = vj.VmecInput.from_file(os.path.join(input_dir, 'input.LandremanPaul2021_QA_reactorScale_lowres'))
+seed = vj.scale_input(seed, r_scale=1./float(seed.rbc[seed.ntor, 0]))
+seed = replace(seed, lfreeb=True, mgrid_file='essos_coils', nzeta=16, phiedge=phiedge,
+               ns_array=[ns], niter_array=[4000], ftol_array=[1e-10])
+
+# Solve the free boundary in vmex
+time0 = time()
+result = vj.solve_free_boundary(seed, external_field=external_field, error_on_no_convergence=False)
+wout = vj.wout_from_state(inp=seed, state=result.state, fsqr=float(result.fsqr),
+                          fsqz=float(result.fsqz), fsql=float(result.fsql),
+                          niter=int(result.iterations), converged=bool(result.converged),
+                          vacuum_output=result.vacuum)
+print(f"vmex free-boundary solve took {time()-time0:.2f} seconds, converged: {bool(result.converged)}")
+print(f"Aspect ratio {float(wout.aspect):.3f}, |B| on axis {abs(float(wout.b0)):.4f} T")
+
+# Read it back as an ESSOS field.  Released vmex hands the equilibrium over as
+# a wout file, which is also what essos.fields.Vmec reads.
+wout_file = os.path.join(output_dir, 'wout_essos_coils_QA.nc')
+vj.write_wout(wout_file, wout)
+vmec = Vmec(wout_file)
+
+# Trace field lines: in flux coordinates ds/dt vanishes, so iota is the slope
+# of theta against phi.  vmex computed iotaf independently from force balance.
+initial_conditions = jnp.array([[s_fieldline]*nfieldlines,
+                                jnp.linspace(0, 2*jnp.pi, nfieldlines, endpoint=False),
+                                jnp.zeros(nfieldlines)]).T
+time0 = time()
+tracing = Tracing(field=vmec, model='FieldLine', initial_conditions=initial_conditions,
+                  maxtime=tmax_fieldline, timestep=1e-2, times_to_trace=num_steps)
+print(f"ESSOS field-line tracing took {time()-time0:.2f} seconds")
+trajectories = np.asarray(tracing.trajectories)
+iota_essos = np.mean([np.polyfit(trajectories[i, :, 2], trajectories[i, :, 1], 1)[0]
+                      for i in range(nfieldlines)])
+iota_vmex = float(np.interp(s_fieldline, np.linspace(0, 1, int(wout.ns)), np.asarray(wout.iotaf)))
+print(f"iota at s={s_fieldline}: {iota_essos:.6f} traced, {iota_vmex:.6f} from vmex")
+
+# Plot the coils, the solved boundary and the traced field lines
+if not CI:
+    fig = plt.figure(figsize=(9, 4.5))
+    ax1 = fig.add_subplot(121, projection='3d')
+    ax2 = fig.add_subplot(122)
+    coils.plot(ax=ax1, show=False)
+    vmec.surface.plot(ax=ax1, show=False, alpha=0.4)
+    tracing.plot(ax=ax1, show=False)
+    # poincare_plot reads trajectories as XYZ; the traced ones are (s, theta, phi)
+    tracing.trajectories = vmap(vmap(vmec.to_xyz, in_axes=0), in_axes=0)(trajectories)
+    tracing.poincare_plot(ax=ax2, show=False, shifts=[0])
+    plt.tight_layout()
+    plt.savefig(os.path.join(output_dir, 'equilibrium_from_coils_vmex.png'))
+    plt.show()


### PR DESCRIPTION
> **Needs the project's external reviewer.** ESSOS PRs are not self-merged.

## Why

ESSOS optimizes coils. The equilibrium those coils hold is what VMEX
(`pip install vmex`, a JAX implementation of VMEC) solves. The two packages fit
together without either importing the other -- coils leave ESSOS as a
Biot-Savart field tabulated onto a cylindrical grid, which is what VMEX's
free-boundary solver consumes, and the equilibrium comes back as a wout file,
which is what `essos.fields.Vmec` already reads. Nothing in the repository
showed that.

## What this adds

`examples/simple_examples/equilibrium_from_coils_vmex.py`, in the directory that
already holds the cross-package scripts (`coils_from_BOOZ_XFORM.py`):

1. loads the bundled Landreman-Paul QA `Coils` and vmaps `BiotSavart.B` into the
   batch callable VMEX's tabulator wants;
2. `vj.MgridField.from_cartesian_field(...)` -> the external field;
3. `vj.scale_input` maps the reactor-scale QA deck this repository ships onto the
   unit size those coils were optimized for, to seed the guess;
4. `vj.solve_free_boundary(...)` -> a converged vacuum equilibrium whose last
   closed surface was found by the coils, not prescribed;
5. `vj.write_wout` -> `essos.fields.Vmec` -> `Tracing(model='FieldLine')`, and
   the rotational transform measured from the trace is compared with the one
   VMEX computed from force balance.

Plus a short section in `README.md` and `docs/getting_started.rst` pointing at
it.

Measured output:

```
Tabulating 16 filaments took 0.63 seconds
vmex free-boundary solve took 48.84 seconds, converged: True
Aspect ratio 6.012, |B| on axis 0.2637 T
ESSOS field-line tracing took 7.04 seconds
iota at s=0.5: 0.417488 traced, 0.417531 from vmex
```

The figure shows the coils with the solved surface in 3-D and the Poincare
section of the traced lines.

## Scope

Deliberately limited to **released VMEX 0.6.0** (the PyPI wheel):
`MgridField.from_cartesian_field`, `scale_input`, `solve_free_boundary`,
`wout_from_state`, `write_wout`. No unreleased API, and nothing here depends on
#61 or on any other open ESSOS branch -- the ESSOS surface used is `Coils`,
`BiotSavart`, `Vmec` and `Tracing`.

VMEX has a companion PR (uwplasma/vmex#146) documenting the same two seams from
its side and adding one-call helpers for both directions. Once that is released
the tabulation block here shortens to `vj.MgridField.from_coils(coils, ...)`;
until then the explicit vmap-and-chunk wrapper is what the released wheel needs,
so it is what this example shows.

`README.md`'s Project Structure tree is already stale (flat `examples/` listing,
`inputs/` rather than `input_files/`) and is left alone rather than half-fixed.

## Local verification

macOS 14.4, MacPorts Python 3.11, jax/jaxlib 0.9.2, VMEX 0.6.0 from PyPI-tagged
main, ESSOS at this branch.

| Check | Result |
| --- | --- |
| `pytest tests/` | 79 passed, 1 xfailed, 30.9 s |
| `flake8 --select=E9,F63,F7,F82` on the new example | 0 |
| `flake8 --max-line-length=127` on the new example | only the 10 `E402`s every ESSOS example has from the `XLA_FLAGS` prologue |
| example, full run | exit 0, 62.6 s, figure and wout written to `examples/output/` |
| example, `VMEX_EXAMPLES_CI=1` | exit 0, 48.8 s, plot skipped |

The `VMEX_EXAMPLES_CI` switch is the one VMEX's own examples read; it is the
single concession to the other repository's conventions, and it exists so the
script can be smoke-run headless.

Not verified: GPU, and any Python other than 3.11.
