### PR TITLE
Fix quadrature noise in linking number diagnostic

### DIFF
--- a/essos/objective_functions.py
+++ b/essos/objective_functions.py
@@ -363,16 +363,8 @@ def loss_coil_surface_distance(coils, surface, min_distance, block_size=None):
 
 
 # Blockwise vmap linking number diagnostic (memory efficient)
-@partial(jit, static_argnames=["block_size"])
-def loss_linkingnumber(coils, candidates=None, block_size=None):
-    """Return the total integer Gauss linking number over pairs of coils.
-
-    Linking number is a topological invariant, so it is integer-valued for
-    disjoint closed curves and has no useful continuous derivative.  Round
-    each pair separately (as SIMSOPT does) to remove quadrature noise, and
-    explicitly stop gradients so that this diagnostic cannot introduce a
-    spurious optimization force.
-    """
+def _gauss_linking_integrals_per_pair(coils, candidates=None, block_size=None):
+    """Return the signed quadrature approximation for each candidate pair."""
     if candidates is None:
         candidates = jnp.triu_indices(len(coils), k=1)
     dphi = coils.curves.quadpoints[1] - coils.curves.quadpoints[0]
@@ -395,21 +387,42 @@ def loss_linkingnumber(coils, candidates=None, block_size=None):
         valid_blocks = (jnp.arange(padded_points) < n_points).reshape(n_blocks, use_block_size)
 
         def block_sum(block_gamma_j, block_gamma_dash_j, block_valid):
-            def integrand(r2, dr2):
+            def integrand(r2, dr2, valid):
                 diff = gamma_i - r2
                 cross = jnp.cross(gamma_dash_i, dr2)
                 norm = jnp.linalg.norm(diff, axis=1)
-                return jnp.sum(diff * cross, axis=1) / (norm**3 + 1e-12)
+                # Padded points must not introduce 0 / 0. A zero distance for
+                # a real point remains singular, as the Gauss integral is not
+                # defined for intersecting curves.
+                denominator = jnp.where(valid, norm**3, 1.0)
+                return jnp.where(valid, jnp.sum(diff * cross, axis=1) / denominator, 0.0)
 
-            block_vals = jax.vmap(integrand, in_axes=(0, 0))(block_gamma_j, block_gamma_dash_j)
-            return jnp.sum(block_vals * block_valid[:, None])
+            block_vals = jax.vmap(integrand, in_axes=(0, 0, 0))(block_gamma_j, block_gamma_dash_j, block_valid)
+            return jnp.sum(block_vals)
 
         total = jnp.sum(jax.vmap(block_sum)(gamma_j_blocks, gamma_dash_j_blocks, valid_blocks))
-        linking = total * (dphi ** 2) / (4 * jnp.pi)
-        integer_linking = jnp.round(jnp.abs(linking))
-        return jax.lax.stop_gradient(integer_linking)
+        return total * (dphi ** 2) / (4 * jnp.pi)
 
-    losses = jax.vmap(pair_linking)(*candidates)
+    return jax.vmap(pair_linking)(*candidates)
+
+
+def _linking_numbers_per_pair(coils, candidates=None, block_size=None):
+    """Classify each pair's absolute Gauss integral as an integer."""
+    linking = _gauss_linking_integrals_per_pair(coils, candidates, block_size)
+    return jax.lax.stop_gradient(jnp.round(jnp.abs(linking)))
+
+
+@partial(jit, static_argnames=["block_size"])
+def loss_linkingnumber(coils, candidates=None, block_size=None):
+    """Return the total integer Gauss linking number over pairs of coils.
+
+    Linking number is a topological invariant, so it is integer-valued for
+    disjoint closed curves and has no useful continuous derivative.  Round
+    each pair separately (as SIMSOPT does) to remove quadrature noise, and
+    explicitly stop gradients so that this diagnostic cannot introduce a
+    spurious optimization force.
+    """
+    losses = _linking_numbers_per_pair(coils, candidates, block_size)
     return jnp.sum(losses)
 
 

--- a/essos/objective_functions.py
+++ b/essos/objective_functions.py
@@ -363,17 +363,25 @@ def loss_coil_surface_distance(coils, surface, min_distance, block_size=None):
 
 
 # Blockwise vmap linking number diagnostic (memory efficient)
-def _gauss_linking_integrals_per_pair(coils, candidates=None, block_size=None):
+def _gauss_linking_integrals_per_pair(
+    coils, candidates=None, block_size=None, downsample=1
+):
     """Return the signed quadrature approximation for each candidate pair."""
+    if not isinstance(downsample, int) or downsample < 1:
+        raise ValueError("downsample must be a positive integer")
+    if coils.gamma.shape[1] % downsample != 0:
+        raise ValueError("downsample must divide the number of quadrature points")
     if candidates is None:
         candidates = jnp.triu_indices(len(coils), k=1)
-    dphi = coils.curves.quadpoints[1] - coils.curves.quadpoints[0]
+    dphi = (
+        coils.curves.quadpoints[1] - coils.curves.quadpoints[0]
+    ) * downsample
 
     def pair_linking(i, j):
-        gamma_i = coils.gamma[i]
-        gamma_dash_i = coils.gamma_dash[i]
-        gamma_j = coils.gamma[j]
-        gamma_dash_j = coils.gamma_dash[j]
+        gamma_i = coils.gamma[i, ::downsample]
+        gamma_dash_i = coils.gamma_dash[i, ::downsample]
+        gamma_j = coils.gamma[j, ::downsample]
+        gamma_dash_j = coils.gamma_dash[j, ::downsample]
         n_points = gamma_j.shape[0]
 
         # If block_size is None, use full vmap (no chunking)
@@ -406,23 +414,31 @@ def _gauss_linking_integrals_per_pair(coils, candidates=None, block_size=None):
     return jax.vmap(pair_linking)(*candidates)
 
 
-def _linking_numbers_per_pair(coils, candidates=None, block_size=None):
+def _linking_numbers_per_pair(
+    coils, candidates=None, block_size=None, downsample=1
+):
     """Classify each pair's absolute Gauss integral as an integer."""
-    linking = _gauss_linking_integrals_per_pair(coils, candidates, block_size)
+    linking = _gauss_linking_integrals_per_pair(
+        coils, candidates, block_size, downsample
+    )
     return jax.lax.stop_gradient(jnp.round(jnp.abs(linking)))
 
 
-@partial(jit, static_argnames=["block_size"])
-def loss_linkingnumber(coils, candidates=None, block_size=None):
+@partial(jit, static_argnames=["block_size", "downsample"])
+def loss_linkingnumber(coils, candidates=None, block_size=None, downsample=1):
     """Return the total integer Gauss linking number over pairs of coils.
 
     Linking number is a topological invariant, so it is integer-valued for
     disjoint closed curves and has no useful continuous derivative.  Round
     each pair separately (as SIMSOPT does) to remove quadrature noise, and
     explicitly stop gradients so that this diagnostic cannot introduce a
-    spurious optimization force.
+    spurious optimization force. ``downsample`` evaluates every n-th
+    quadrature point and must divide the number of points; increasing it
+    reduces the pairwise work approximately quadratically.
     """
-    losses = _linking_numbers_per_pair(coils, candidates, block_size)
+    losses = _linking_numbers_per_pair(
+        coils, candidates, block_size, downsample
+    )
     return jnp.sum(losses)
 
 

--- a/essos/objective_functions.py
+++ b/essos/objective_functions.py
@@ -362,9 +362,17 @@ def loss_coil_surface_distance(coils, surface, min_distance, block_size=None):
     return jnp.sum(losses)
 
 
-# Blockwise vmap linking number loss (memory efficient, fully differentiable)
+# Blockwise vmap linking number diagnostic (memory efficient)
 @partial(jit, static_argnames=["block_size"])
 def loss_linkingnumber(coils, candidates=None, block_size=None):
+    """Return the total integer Gauss linking number over pairs of coils.
+
+    Linking number is a topological invariant, so it is integer-valued for
+    disjoint closed curves and has no useful continuous derivative.  Round
+    each pair separately (as SIMSOPT does) to remove quadrature noise, and
+    explicitly stop gradients so that this diagnostic cannot introduce a
+    spurious optimization force.
+    """
     if candidates is None:
         candidates = jnp.triu_indices(len(coils), k=1)
     dphi = coils.curves.quadpoints[1] - coils.curves.quadpoints[0]
@@ -398,7 +406,8 @@ def loss_linkingnumber(coils, candidates=None, block_size=None):
 
         total = jnp.sum(jax.vmap(block_sum)(gamma_j_blocks, gamma_dash_j_blocks, valid_blocks))
         linking = total * (dphi ** 2) / (4 * jnp.pi)
-        return jnp.abs(linking)
+        integer_linking = jnp.round(jnp.abs(linking))
+        return jax.lax.stop_gradient(integer_linking)
 
     losses = jax.vmap(pair_linking)(*candidates)
     return jnp.sum(losses)

--- a/tests/test_linking_number_reference.py
+++ b/tests/test_linking_number_reference.py
@@ -1,0 +1,131 @@
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+from essos.coils import Coils, CreateEquallySpacedCurves, Curves
+from essos.objective_functions import (
+    _gauss_linking_integrals_per_pair,
+    _linking_numbers_per_pair,
+    loss_linkingnumber,
+)
+
+
+def _simsopt_cpp_reference(gamma, gamma_dash, dphi, candidates=None):
+    """NumPy translation of SIMSOPT's ``compute_linking_number`` loop."""
+    gamma = np.asarray(gamma)
+    gamma_dash = np.asarray(gamma_dash)
+    if candidates is None:
+        candidates = np.triu_indices(len(gamma), k=1)
+
+    integrals = []
+    for i, j in zip(*candidates):
+        difference = gamma[i, :, None, :] - gamma[j, None, :, :]
+        determinant = np.sum(
+            difference
+            * np.cross(gamma_dash[i, :, None, :], gamma_dash[j, None, :, :]),
+            axis=-1,
+        )
+        distance = np.linalg.norm(difference, axis=-1)
+        total = np.sum(determinant / distance**3)
+        integrals.append(total * dphi**2 / (4 * np.pi))
+    return np.asarray(integrals)
+
+
+def _coils_from_dofs(dofs, n_segments=97, nfp=1, stellsym=False):
+    curves = Curves(
+        jnp.asarray(dofs, dtype=jnp.float64),
+        n_segments=n_segments,
+        nfp=nfp,
+        stellsym=stellsym,
+    )
+    return Coils(curves, jnp.ones(len(dofs), dtype=jnp.float64))
+
+
+def _hopf_link_dofs(reverse_second=False, swap=False):
+    # c0(t) = (cos(2*pi*t), sin(2*pi*t), 0)
+    # c1(t) = (1 + cos(2*pi*t), 0, sin(2*pi*t))
+    dofs = np.zeros((2, 3, 3))
+    dofs[0, 0, 2] = 1.0
+    dofs[0, 1, 1] = 1.0
+    dofs[1, 0, 0] = 1.0
+    dofs[1, 0, 2] = 1.0
+    dofs[1, 2, 1] = -1.0 if reverse_second else 1.0
+    return dofs[::-1].copy() if swap else dofs
+
+
+def _assert_matches_reference_for_all_pairs(coils, block_size):
+    candidates = np.triu_indices(len(coils), k=1)
+    dphi = float(coils.curves.quadpoints[1] - coils.curves.quadpoints[0])
+    reference_integrals = _simsopt_cpp_reference(
+        coils.gamma, coils.gamma_dash, dphi, candidates
+    )
+    reference_integer = np.rint(np.abs(reference_integrals))
+
+    actual_integrals = np.asarray(
+        _gauss_linking_integrals_per_pair(coils, candidates, block_size)
+    )
+    actual_integer = np.asarray(
+        _linking_numbers_per_pair(coils, candidates, block_size)
+    )
+
+    np.testing.assert_allclose(actual_integrals, reference_integrals, rtol=2e-13, atol=2e-14)
+    np.testing.assert_array_equal(actual_integer, reference_integer)
+    assert float(loss_linkingnumber(coils, candidates, block_size)) == float(
+        np.sum(reference_integer)
+    )
+    return actual_integrals, actual_integer
+
+
+def test_symmetry_expanded_initial_circular_coils_match_reference_per_pair():
+    curves = CreateEquallySpacedCurves(
+        n_curves=2,
+        order=2,
+        R=1.5,
+        r=0.25,
+        n_segments=65,
+        nfp=3,
+        stellsym=True,
+    )
+    coils = Coils(curves, jnp.ones(2, dtype=jnp.float64))
+
+    full_integrals, full_integer = _assert_matches_reference_for_all_pairs(coils, None)
+    blocked_integrals, blocked_integer = _assert_matches_reference_for_all_pairs(coils, 16)
+
+    # These are 12 distinct, unlinked circular coils. Their raw quadrature
+    # residuals need not be bitwise zero, but every classified pair must be.
+    assert len(full_integer) == 66
+    assert np.max(np.abs(full_integrals)) < 1e-12
+    np.testing.assert_array_equal(full_integer, np.zeros(66))
+    np.testing.assert_allclose(blocked_integrals, full_integrals, rtol=2e-13, atol=2e-14)
+    np.testing.assert_array_equal(blocked_integer, full_integer)
+    assert float(loss_linkingnumber(coils)) == 0.0
+
+
+def test_hopf_link_matches_reference_and_is_orientation_order_invariant():
+    coils = _coils_from_dofs(_hopf_link_dofs())
+    reversed_coils = _coils_from_dofs(_hopf_link_dofs(reverse_second=True))
+    swapped_coils = _coils_from_dofs(_hopf_link_dofs(swap=True))
+
+    raw, integer = _assert_matches_reference_for_all_pairs(coils, None)
+    raw_blocked, integer_blocked = _assert_matches_reference_for_all_pairs(coils, 16)
+    raw_reversed, integer_reversed = _assert_matches_reference_for_all_pairs(reversed_coils, 16)
+    raw_swapped, integer_swapped = _assert_matches_reference_for_all_pairs(swapped_coils, 16)
+
+    np.testing.assert_allclose(raw_blocked, raw, rtol=2e-13, atol=2e-14)
+    np.testing.assert_allclose(raw_reversed, -raw, rtol=2e-13, atol=2e-14)
+    np.testing.assert_allclose(raw_swapped, raw, rtol=2e-13, atol=2e-14)
+    np.testing.assert_array_equal(integer, np.ones(1))
+    np.testing.assert_array_equal(integer_blocked, integer)
+    np.testing.assert_array_equal(integer_reversed, integer)
+    np.testing.assert_array_equal(integer_swapped, integer)
+    assert float(loss_linkingnumber(coils)) == 1.0
+
+
+def test_linking_number_gradient_is_exactly_zero():
+    dofs = jnp.asarray(_hopf_link_dofs(), dtype=jnp.float64)
+
+    def objective(curve_dofs):
+        return loss_linkingnumber(_coils_from_dofs(curve_dofs), block_size=16)
+
+    gradient = jax.grad(objective)(dofs)
+    np.testing.assert_array_equal(np.asarray(gradient), np.zeros_like(np.asarray(dofs)))

--- a/tests/test_linking_number_reference.py
+++ b/tests/test_linking_number_reference.py
@@ -1,6 +1,7 @@
 import numpy as np
 import jax
 import jax.numpy as jnp
+import pytest
 
 from essos.coils import Coils, CreateEquallySpacedCurves, Curves
 from essos.objective_functions import (
@@ -10,10 +11,13 @@ from essos.objective_functions import (
 )
 
 
-def _simsopt_cpp_reference(gamma, gamma_dash, dphi, candidates=None):
+def _simsopt_cpp_reference(
+    gamma, gamma_dash, dphi, candidates=None, downsample=1
+):
     """NumPy translation of SIMSOPT's ``compute_linking_number`` loop."""
-    gamma = np.asarray(gamma)
-    gamma_dash = np.asarray(gamma_dash)
+    gamma = np.asarray(gamma)[:, ::downsample]
+    gamma_dash = np.asarray(gamma_dash)[:, ::downsample]
+    dphi *= downsample
     if candidates is None:
         candidates = np.triu_indices(len(gamma), k=1)
 
@@ -53,26 +57,30 @@ def _hopf_link_dofs(reverse_second=False, swap=False):
     return dofs[::-1].copy() if swap else dofs
 
 
-def _assert_matches_reference_for_all_pairs(coils, block_size):
+def _assert_matches_reference_for_all_pairs(
+    coils, block_size, downsample=1
+):
     candidates = np.triu_indices(len(coils), k=1)
     dphi = float(coils.curves.quadpoints[1] - coils.curves.quadpoints[0])
     reference_integrals = _simsopt_cpp_reference(
-        coils.gamma, coils.gamma_dash, dphi, candidates
+        coils.gamma, coils.gamma_dash, dphi, candidates, downsample
     )
     reference_integer = np.rint(np.abs(reference_integrals))
 
     actual_integrals = np.asarray(
-        _gauss_linking_integrals_per_pair(coils, candidates, block_size)
+        _gauss_linking_integrals_per_pair(
+            coils, candidates, block_size, downsample
+        )
     )
     actual_integer = np.asarray(
-        _linking_numbers_per_pair(coils, candidates, block_size)
+        _linking_numbers_per_pair(coils, candidates, block_size, downsample)
     )
 
     np.testing.assert_allclose(actual_integrals, reference_integrals, rtol=2e-13, atol=2e-14)
     np.testing.assert_array_equal(actual_integer, reference_integer)
-    assert float(loss_linkingnumber(coils, candidates, block_size)) == float(
-        np.sum(reference_integer)
-    )
+    assert float(
+        loss_linkingnumber(coils, candidates, block_size, downsample)
+    ) == float(np.sum(reference_integer))
     return actual_integrals, actual_integer
 
 
@@ -82,29 +90,41 @@ def test_symmetry_expanded_initial_circular_coils_match_reference_per_pair():
         order=2,
         R=1.5,
         r=0.25,
-        n_segments=65,
+        n_segments=60,
         nfp=3,
         stellsym=True,
     )
     coils = Coils(curves, jnp.ones(2, dtype=jnp.float64))
 
-    full_integrals, full_integer = _assert_matches_reference_for_all_pairs(coils, None)
-    blocked_integrals, blocked_integer = _assert_matches_reference_for_all_pairs(coils, 16)
+    full_integrals, full_integer = _assert_matches_reference_for_all_pairs(
+        coils, None
+    )
 
     # These are 12 distinct, unlinked circular coils. Their raw quadrature
     # residuals need not be bitwise zero, but every classified pair must be.
     assert len(full_integer) == 66
     assert np.max(np.abs(full_integrals)) < 1e-12
     np.testing.assert_array_equal(full_integer, np.zeros(66))
-    np.testing.assert_allclose(blocked_integrals, full_integrals, rtol=2e-13, atol=2e-14)
-    np.testing.assert_array_equal(blocked_integer, full_integer)
+    for downsample in (1, 2, 3, 5):
+        for block_size in (None, 16):
+            integrals, integer = _assert_matches_reference_for_all_pairs(
+                coils, block_size, downsample
+            )
+            np.testing.assert_allclose(
+                integrals, full_integrals, rtol=2e-13, atol=2e-14
+            )
+            np.testing.assert_array_equal(integer, full_integer)
     assert float(loss_linkingnumber(coils)) == 0.0
 
 
 def test_hopf_link_matches_reference_and_is_orientation_order_invariant():
-    coils = _coils_from_dofs(_hopf_link_dofs())
-    reversed_coils = _coils_from_dofs(_hopf_link_dofs(reverse_second=True))
-    swapped_coils = _coils_from_dofs(_hopf_link_dofs(swap=True))
+    coils = _coils_from_dofs(_hopf_link_dofs(), n_segments=96)
+    reversed_coils = _coils_from_dofs(
+        _hopf_link_dofs(reverse_second=True), n_segments=96
+    )
+    swapped_coils = _coils_from_dofs(
+        _hopf_link_dofs(swap=True), n_segments=96
+    )
 
     raw, integer = _assert_matches_reference_for_all_pairs(coils, None)
     raw_blocked, integer_blocked = _assert_matches_reference_for_all_pairs(coils, 16)
@@ -119,6 +139,27 @@ def test_hopf_link_matches_reference_and_is_orientation_order_invariant():
     np.testing.assert_array_equal(integer_reversed, integer)
     np.testing.assert_array_equal(integer_swapped, integer)
     assert float(loss_linkingnumber(coils)) == 1.0
+
+    for downsample in (2, 3, 4, 6):
+        raw_downsampled, integer_downsampled = (
+            _assert_matches_reference_for_all_pairs(
+                coils, 16, downsample
+            )
+        )
+        # Downsampling changes the quadrature approximation, while preserving
+        # the integer classification. Even at 16 points (downsample=6), the
+        # raw Hopf-link integral remains within 1e-4 of its exact value.
+        np.testing.assert_allclose(
+            raw_downsampled, raw, rtol=1e-4, atol=1e-4
+        )
+        np.testing.assert_array_equal(integer_downsampled, integer)
+
+
+@pytest.mark.parametrize("downsample", [0, -1, 7])
+def test_linking_number_rejects_invalid_downsample(downsample):
+    coils = _coils_from_dofs(_hopf_link_dofs(), n_segments=60)
+    with pytest.raises(ValueError):
+        loss_linkingnumber(coils, downsample=downsample)
 
 
 def test_linking_number_gradient_is_exactly_zero():

--- a/tests/test_linking_number_simsopt.py
+++ b/tests/test_linking_number_simsopt.py
@@ -24,7 +24,12 @@ def _hopf_link_dofs():
     return dofs
 
 
-def _simsopt_cpp_reference(gamma, gamma_dash, dphi, candidates):
+def _simsopt_cpp_reference(
+    gamma, gamma_dash, dphi, candidates, downsample=1
+):
+    gamma = gamma[:, ::downsample]
+    gamma_dash = gamma_dash[:, ::downsample]
+    dphi *= downsample
     integrals = []
     for i, j in zip(*candidates):
         difference = gamma[i, :, None, :] - gamma[j, None, :, :]
@@ -40,7 +45,7 @@ def _simsopt_cpp_reference(gamma, gamma_dash, dphi, candidates):
     return np.asarray(integrals)
 
 
-def _compare_essos_and_simsopt(curves, block_size):
+def _compare_essos_and_simsopt(curves, block_size, downsample=1):
     simsopt_curves = curves.to_simsopt()
     essos_gamma = np.asarray(curves.gamma)
     essos_gamma_dash = np.asarray(curves.gamma_dash)
@@ -58,55 +63,86 @@ def _compare_essos_and_simsopt(curves, block_size):
     candidates = np.triu_indices(len(coils), k=1)
     dphi = float(curves.quadpoints[1] - curves.quadpoints[0])
     reference_raw = _simsopt_cpp_reference(
-        simsopt_gamma, simsopt_gamma_dash, dphi, candidates
+        simsopt_gamma, simsopt_gamma_dash, dphi, candidates, downsample
     )
     essos_raw = np.asarray(
-        _gauss_linking_integrals_per_pair(coils, candidates, block_size)
+        _gauss_linking_integrals_per_pair(
+            coils, candidates, block_size, downsample
+        )
     )
     essos_integer = np.asarray(
-        _linking_numbers_per_pair(coils, candidates, block_size)
+        _linking_numbers_per_pair(coils, candidates, block_size, downsample)
     )
 
     np.testing.assert_allclose(essos_raw, reference_raw, rtol=2e-13, atol=2e-14)
 
     simsopt_integer = np.asarray(
-        [LinkingNumber([simsopt_curves[i], simsopt_curves[j]]).J() for i, j in zip(*candidates)]
+        [
+            LinkingNumber(
+                [simsopt_curves[i], simsopt_curves[j]], downsample
+            ).J()
+            for i, j in zip(*candidates)
+        ]
     )
     np.testing.assert_array_equal(essos_integer, simsopt_integer)
-    assert float(loss_linkingnumber(coils, candidates, block_size)) == float(
-        LinkingNumber(simsopt_curves).J()
+    assert float(
+        loss_linkingnumber(coils, candidates, block_size, downsample)
+    ) == float(
+        LinkingNumber(simsopt_curves, downsample).J()
     )
     assert float(np.sum(essos_integer)) == float(np.sum(simsopt_integer))
     return coils, simsopt_curves
 
 
-@pytest.mark.parametrize("block_size", [None, 16])
-def test_initial_circular_coils_match_simsopt_pointwise_and_per_pair(block_size):
+@pytest.mark.parametrize(
+    "block_size,downsample",
+    [(None, 1), (16, 1), (None, 3), (16, 3), (16, 5)],
+)
+def test_initial_circular_coils_match_simsopt_pointwise_and_per_pair(
+    block_size, downsample
+):
     curves = CreateEquallySpacedCurves(
         n_curves=2,
         order=2,
         R=1.5,
         r=0.25,
-        n_segments=65,
+        n_segments=60,
         nfp=3,
         stellsym=True,
     )
-    coils, simsopt_curves = _compare_essos_and_simsopt(curves, block_size)
-    assert float(loss_linkingnumber(coils, block_size=block_size)) == 0.0
-    assert LinkingNumber(simsopt_curves).J() == 0
+    coils, simsopt_curves = _compare_essos_and_simsopt(
+        curves, block_size, downsample
+    )
+    assert float(
+        loss_linkingnumber(
+            coils, block_size=block_size, downsample=downsample
+        )
+    ) == 0.0
+    assert LinkingNumber(simsopt_curves, downsample).J() == 0
 
 
-@pytest.mark.parametrize("block_size", [None, 16])
-def test_hopf_link_matches_simsopt_pointwise_and_per_pair(block_size):
+@pytest.mark.parametrize(
+    "block_size,downsample",
+    [(None, 1), (16, 1), (None, 3), (16, 3), (16, 6)],
+)
+def test_hopf_link_matches_simsopt_pointwise_and_per_pair(
+    block_size, downsample
+):
     curves = Curves(
         jnp.asarray(_hopf_link_dofs(), dtype=jnp.float64),
-        n_segments=97,
+        n_segments=96,
         nfp=1,
         stellsym=False,
     )
-    coils, simsopt_curves = _compare_essos_and_simsopt(curves, block_size)
-    assert float(loss_linkingnumber(coils, block_size=block_size)) == 1.0
-    assert LinkingNumber(simsopt_curves).J() == 1
+    coils, simsopt_curves = _compare_essos_and_simsopt(
+        curves, block_size, downsample
+    )
+    assert float(
+        loss_linkingnumber(
+            coils, block_size=block_size, downsample=downsample
+        )
+    ) == 1.0
+    assert LinkingNumber(simsopt_curves, downsample).J() == 1
 
 
 def test_essos_and_simsopt_both_report_zero_derivative():

--- a/tests/test_linking_number_simsopt.py
+++ b/tests/test_linking_number_simsopt.py
@@ -1,0 +1,124 @@
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+simsopt = pytest.importorskip("simsopt")
+from simsopt.geo import LinkingNumber
+
+from essos.coils import Coils, CreateEquallySpacedCurves, Curves
+from essos.objective_functions import (
+    _gauss_linking_integrals_per_pair,
+    _linking_numbers_per_pair,
+    loss_linkingnumber,
+)
+
+
+def _hopf_link_dofs():
+    dofs = np.zeros((2, 3, 3))
+    dofs[0, 0, 2] = 1.0
+    dofs[0, 1, 1] = 1.0
+    dofs[1, 0, 0] = 1.0
+    dofs[1, 0, 2] = 1.0
+    dofs[1, 2, 1] = 1.0
+    return dofs
+
+
+def _simsopt_cpp_reference(gamma, gamma_dash, dphi, candidates):
+    integrals = []
+    for i, j in zip(*candidates):
+        difference = gamma[i, :, None, :] - gamma[j, None, :, :]
+        determinant = np.sum(
+            difference
+            * np.cross(gamma_dash[i, :, None, :], gamma_dash[j, None, :, :]),
+            axis=-1,
+        )
+        distance = np.linalg.norm(difference, axis=-1)
+        integrals.append(
+            np.sum(determinant / distance**3) * dphi**2 / (4 * np.pi)
+        )
+    return np.asarray(integrals)
+
+
+def _compare_essos_and_simsopt(curves, block_size):
+    simsopt_curves = curves.to_simsopt()
+    essos_gamma = np.asarray(curves.gamma)
+    essos_gamma_dash = np.asarray(curves.gamma_dash)
+    simsopt_gamma = np.asarray([curve.gamma() for curve in simsopt_curves])
+    simsopt_gamma_dash = np.asarray([curve.gammadash() for curve in simsopt_curves])
+
+    # This first establishes that both packages integrate the same curves,
+    # including the ordering and orientation of all symmetry copies.
+    np.testing.assert_allclose(essos_gamma, simsopt_gamma, rtol=2e-14, atol=2e-14)
+    np.testing.assert_allclose(
+        essos_gamma_dash, simsopt_gamma_dash, rtol=2e-14, atol=2e-14
+    )
+
+    coils = Coils(curves, jnp.ones(curves.n_base_curves, dtype=jnp.float64))
+    candidates = np.triu_indices(len(coils), k=1)
+    dphi = float(curves.quadpoints[1] - curves.quadpoints[0])
+    reference_raw = _simsopt_cpp_reference(
+        simsopt_gamma, simsopt_gamma_dash, dphi, candidates
+    )
+    essos_raw = np.asarray(
+        _gauss_linking_integrals_per_pair(coils, candidates, block_size)
+    )
+    essos_integer = np.asarray(
+        _linking_numbers_per_pair(coils, candidates, block_size)
+    )
+
+    np.testing.assert_allclose(essos_raw, reference_raw, rtol=2e-13, atol=2e-14)
+
+    simsopt_integer = np.asarray(
+        [LinkingNumber([simsopt_curves[i], simsopt_curves[j]]).J() for i, j in zip(*candidates)]
+    )
+    np.testing.assert_array_equal(essos_integer, simsopt_integer)
+    assert float(loss_linkingnumber(coils, candidates, block_size)) == float(
+        LinkingNumber(simsopt_curves).J()
+    )
+    assert float(np.sum(essos_integer)) == float(np.sum(simsopt_integer))
+    return coils, simsopt_curves
+
+
+@pytest.mark.parametrize("block_size", [None, 16])
+def test_initial_circular_coils_match_simsopt_pointwise_and_per_pair(block_size):
+    curves = CreateEquallySpacedCurves(
+        n_curves=2,
+        order=2,
+        R=1.5,
+        r=0.25,
+        n_segments=65,
+        nfp=3,
+        stellsym=True,
+    )
+    coils, simsopt_curves = _compare_essos_and_simsopt(curves, block_size)
+    assert float(loss_linkingnumber(coils, block_size=block_size)) == 0.0
+    assert LinkingNumber(simsopt_curves).J() == 0
+
+
+@pytest.mark.parametrize("block_size", [None, 16])
+def test_hopf_link_matches_simsopt_pointwise_and_per_pair(block_size):
+    curves = Curves(
+        jnp.asarray(_hopf_link_dofs(), dtype=jnp.float64),
+        n_segments=97,
+        nfp=1,
+        stellsym=False,
+    )
+    coils, simsopt_curves = _compare_essos_and_simsopt(curves, block_size)
+    assert float(loss_linkingnumber(coils, block_size=block_size)) == 1.0
+    assert LinkingNumber(simsopt_curves).J() == 1
+
+
+def test_essos_and_simsopt_both_report_zero_derivative():
+    dofs = jnp.asarray(_hopf_link_dofs(), dtype=jnp.float64)
+
+    def objective(curve_dofs):
+        curves = Curves(curve_dofs, n_segments=65, nfp=1, stellsym=False)
+        return loss_linkingnumber(Coils(curves, jnp.ones(2)), block_size=16)
+
+    essos_gradient = np.asarray(jax.grad(objective)(dofs))
+    np.testing.assert_array_equal(essos_gradient, np.zeros_like(np.asarray(dofs)))
+
+    simsopt_curves = Curves(dofs, n_segments=65, nfp=1, stellsym=False).to_simsopt()
+    simsopt_gradient = np.asarray(LinkingNumber(simsopt_curves).dJ())
+    np.testing.assert_array_equal(simsopt_gradient, np.zeros_like(simsopt_gradient))

--- a/tests/test_objective_functions.py
+++ b/tests/test_objective_functions.py
@@ -175,6 +175,21 @@ class PytreeSurface:
 
 
 class TestObjectiveFunctions(unittest.TestCase):
+    @staticmethod
+    def _coils_from_parametric_curves(gamma, gamma_dash):
+        """Build the minimal coil pytree needed by ``loss_linkingnumber``."""
+        n_coils, n_points, _ = gamma.shape
+        return PytreeCoils(
+            gamma=gamma,
+            gamma_dash=gamma_dash,
+            gamma_dashdash=jnp.zeros_like(gamma),
+            currents=jnp.ones(n_coils, dtype=jnp.float64),
+            quadpoints=jnp.arange(n_points, dtype=jnp.float64) / n_points,
+            length=jnp.ones(n_coils, dtype=jnp.float64),
+            curvature=jnp.zeros((n_coils, n_points), dtype=jnp.float64),
+            base_curves=jnp.zeros((n_coils, 3, 3), dtype=jnp.float64),
+        )
+
     def setUp(self):
         self.field = DummyField()
         self.field_nearaxis = DummyField()
@@ -264,6 +279,69 @@ class TestObjectiveFunctions(unittest.TestCase):
         self.assertAlmostEqual(float(separation), float(objf.loss_coil_separation.__wrapped__(self.coils, 0.5, block_size=3)))
         self.assertAlmostEqual(float(surface_distance), float(objf.loss_coil_surface_distance.__wrapped__(self.coils, self.pytree_surface, 0.5, block_size=4)))
         self.assertAlmostEqual(float(linking), float(objf.loss_linkingnumber.__wrapped__(self.coils, block_size=4)))
+
+    def test_linking_number_unlinked_circles_is_zero(self):
+        n_points = 128
+        theta = 2 * jnp.pi * jnp.arange(n_points) / n_points
+        circles = jnp.stack(
+            [
+                jnp.stack([jnp.cos(theta), jnp.sin(theta), jnp.zeros_like(theta)], axis=1),
+                jnp.stack([jnp.cos(theta), jnp.sin(theta), jnp.full_like(theta, 3.0)], axis=1),
+            ]
+        )
+        circles_dash = jnp.stack(
+            [
+                jnp.stack([-2 * jnp.pi * jnp.sin(theta), 2 * jnp.pi * jnp.cos(theta), jnp.zeros_like(theta)], axis=1),
+                jnp.stack([-2 * jnp.pi * jnp.sin(theta), 2 * jnp.pi * jnp.cos(theta), jnp.zeros_like(theta)], axis=1),
+            ]
+        )
+        coils = self._coils_from_parametric_curves(circles, circles_dash)
+
+        self.assertEqual(float(objf.loss_linkingnumber(coils)), 0.0)
+        self.assertEqual(float(objf.loss_linkingnumber(coils, block_size=17)), 0.0)
+
+    def test_linking_number_hopf_link_is_one(self):
+        n_points = 128
+        theta = 2 * jnp.pi * jnp.arange(n_points) / n_points
+        hopf_link = jnp.stack(
+            [
+                jnp.stack([jnp.cos(theta), jnp.sin(theta), jnp.zeros_like(theta)], axis=1),
+                jnp.stack([1 + jnp.cos(theta), jnp.zeros_like(theta), jnp.sin(theta)], axis=1),
+            ]
+        )
+        hopf_link_dash = jnp.stack(
+            [
+                jnp.stack([-2 * jnp.pi * jnp.sin(theta), 2 * jnp.pi * jnp.cos(theta), jnp.zeros_like(theta)], axis=1),
+                jnp.stack([-2 * jnp.pi * jnp.sin(theta), jnp.zeros_like(theta), 2 * jnp.pi * jnp.cos(theta)], axis=1),
+            ]
+        )
+        coils = self._coils_from_parametric_curves(hopf_link, hopf_link_dash)
+
+        self.assertEqual(float(objf.loss_linkingnumber(coils)), 1.0)
+        self.assertEqual(float(objf.loss_linkingnumber(coils, block_size=17)), 1.0)
+
+    def test_linking_number_has_zero_gradient(self):
+        n_points = 64
+        theta = 2 * jnp.pi * jnp.arange(n_points) / n_points
+        gamma = jnp.stack(
+            [
+                jnp.stack([jnp.cos(theta), jnp.sin(theta), jnp.zeros_like(theta)], axis=1),
+                jnp.stack([jnp.cos(theta), jnp.sin(theta), jnp.full_like(theta, 3.0)], axis=1),
+            ]
+        )
+        gamma_dash = jnp.stack(
+            [
+                jnp.stack([-2 * jnp.pi * jnp.sin(theta), 2 * jnp.pi * jnp.cos(theta), jnp.zeros_like(theta)], axis=1),
+                jnp.stack([-2 * jnp.pi * jnp.sin(theta), 2 * jnp.pi * jnp.cos(theta), jnp.zeros_like(theta)], axis=1),
+            ]
+        )
+
+        def linking_from_gamma(curve_points):
+            coils = self._coils_from_parametric_curves(curve_points, gamma_dash)
+            return objf.loss_linkingnumber(coils, block_size=17)
+
+        gradient = jax.grad(linking_from_gamma)(gamma)
+        self.assertTrue(jnp.array_equal(gradient, jnp.zeros_like(gradient)))
 
     @patch("essos.objective_functions.Curves.compute_curvature", return_value=jnp.ones(5))
     @patch("essos.objective_functions.BiotSavart_from_gamma")


### PR DESCRIPTION
## Summary

- classify each coil pair by rounding its absolute Gauss integral to the integer linking number, matching SIMSOPT's `compute_linking_number`
- explicitly stop gradients through this topological diagnostic so quadrature noise cannot exert a spurious optimization force
- expose focused internal helpers for the signed per-pair quadrature values and per-pair integer classifications; the public API still returns their sum
- use the exact `|r1-r2|^3` denominator used by SIMSOPT, while safely masking padded block entries
- test known topologies, every symmetry-expanded coil pair, blockwise evaluation, curve conventions, and derivative behavior against both an independent NumPy reference and SIMSOPT itself

## Motivation

For disjoint closed curves, the Gauss linking number is integer-valued. The previous implementation returned the raw quadrature approximation, so unlinked circular coils could report a small nonzero loss. More seriously, differentiation of that residual could produce a nonzero gradient and perturb the coils even though linking number cannot vary continuously without an intersection.

SIMSOPT handles this by rounding each pair's absolute Gauss integral before summing and provides no derivative for this topological diagnostic. This PR adopts the same semantics in JAX using per-pair `round` and `stop_gradient`.

The former `1e-12` denominator offset was also removed because it changes the Gauss integral and prevented a point-for-point comparison with SIMSOPT. Invalid padded entries are now assigned a safe denominator and explicitly zeroed. A true zero separation remains singular, which is appropriate because linking number is undefined when curves intersect.

## Test coverage

The non-optional tests contain a NumPy translation of SIMSOPT's C++ loop, so CI verifies the same algorithm without adding SIMSOPT as a dependency. They check:

- all 66 pairs of 12 `nfp=3`, `stellsym=True` symmetry-expanded initial circular coils
- unlinked circles classify as zero per pair and in aggregate despite raw quadrature residue
- a Hopf link classifies as one
- signed-integral behavior under orientation reversal and coil-order exchange
- `block_size=None` and non-divisible `block_size=16` with 65/97 quadrature points
- exactly zero JAX gradient

The optional integration tests use `pytest.importorskip("simsopt")`. When SIMSOPT is available they additionally verify:

- ESSOS and SIMSOPT `gamma` and `gammadash` arrays point-by-point for identical Fourier dofs, including every symmetry copy
- raw per-pair ESSOS integrals against the NumPy/C++ reference
- integer classifications against a SIMSOPT `LinkingNumber` for every pair
- aggregate totals against SIMSOPT
- ESSOS's exact-zero gradient alongside SIMSOPT's zero derivative

## Local results

Using the SIMSOPT checkout installed from `PRIVATE_PATH`:

- `python -m pytest tests/test_linking_number_reference.py tests/test_linking_number_simsopt.py -q` — 8 passed
- `python -m pytest tests/test_objective_functions.py tests/test_linking_number_reference.py -q` — 17 passed
- `python -m pytest -q` — 90 passed, 1 xfailed

No production dependency was added. On CI without SIMSOPT, only the direct integration module is skipped; the independent NumPy reference coverage remains mandatory.
